### PR TITLE
Fixed bad code practice

### DIFF
--- a/Sorts/BubbleSort.java
+++ b/Sorts/BubbleSort.java
@@ -14,7 +14,7 @@ class BubbleSort
      * Sorts the array in increasing order
      **/
 
-    public static <T extends Comparable<T>> void BS(T array[], int last) {
+    public static <T extends Comparable<T>> void BS(T[] array, int last) {
         //Sorting
         boolean swap;
         do


### PR DESCRIPTION
It is inadvisable to put the [] after the variable name during declaration.  Instead, try to put them after the variable type.  [Learn more](https://docs.oracle.com/javase/tutorial/java/nutsandbolts/arrays.html).