### PR TITLE
Removing redundant if condition

### DIFF
--- a/Dynamic Programming/CoinChange.java
+++ b/Dynamic Programming/CoinChange.java
@@ -29,9 +29,7 @@ public class CoinChange {
 
         for (int coin : coins) {
             for (int i=coin; i<amount+1; i++) {
-                if (i>=coin) {
                     combinations[i] += combinations[i-coin];
-                }
             }
             // Uncomment the below line to see the state of combinations for each coin
             // printAmount(combinations);


### PR DESCRIPTION
for loop above if condition is starting from coin and operation is increment in loop
so value of i will be always >= coin 
hence if condition is redundant there