### PR TITLE
Remove Tracis CI badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Algorithms - Java [![Build Status](https://travis-ci.org/TheAlgorithms/Java.svg)](https://travis-ci.org/TheAlgorithms/Java)
+# The Algorithms - Java
 
 ### All algorithms implemented in Java (for education)
 


### PR DESCRIPTION
Removing the Travis CI badge as it points to a dead URL. As this repository has [very few tests](https://github.com/TheAlgorithms/Java/search?q=Test&unscoped_q=Test), maybe a CI build might be a bit too much.