### PR TITLE
Updated description for Others/PerlinNoise.java. Fixed compiler warning regarding unclosed scanner.

### DIFF
--- a/Others/PerlinNoise.java
+++ b/Others/PerlinNoise.java
@@ -3,6 +3,7 @@ import java.util.Scanner;
 
 /**
  * For detailed info and implementation see: <a href="http://devmag.org.za/2009/04/25/perlin-noise/">Perlin-Noise</a>
+ * Algorithm description: https://en.wikipedia.org/wiki/Perlin_noise
  */
 public class PerlinNoise {
     /**
@@ -137,7 +138,7 @@ public class PerlinNoise {
         System.out.println("Charset (String): ");
         charset = in.next();
 
-
+        in.close();
         perlinNoise = generatePerlinNoise(width, height, octaveCount, persistence, seed);
         final char[] chars = charset.toCharArray();
         final int length = chars.length;

--- a/Others/ReverseStackUsingRecursion.java
+++ b/Others/ReverseStackUsingRecursion.java
@@ -44,8 +44,7 @@ public class ReverseStackUsingRecursion {
         }
         /* All items are stored in call stack until we reach the end*/
 
-        int temptop=stack.peek();
-        stack.pop();
+        int temptop=stack.pop();
         reverseUsingRecursion(stack); //Recursion call
         insertAtEnd(temptop); // Insert items held in call stack one by one into stack
     }
@@ -66,5 +65,4 @@ public class ReverseStackUsingRecursion {
         }
 
     }
-
 }

--- a/Others/RootPrecision.java
+++ b/Others/RootPrecision.java
@@ -9,20 +9,21 @@ public class RootPrecision {
     public static void main(String[] args) {
 	//take input    
       Scanner scn = new Scanner(System.in);
-      
-      int N = scn.nextInt(); //N is the input number
-      int P = scn.nextInt(); //P is precision value for eg - P is 3 in 2.564 and 5 in 3.80870.
-      
-      System.out.println(squareRoot(N, P));
+      System.out.println("Enter a number that you wish to get the squareroot from: \n>");
+      int Number = scn.nextInt(); //N is the input number
+      System.out.println("How many decimals do you want in the answer? \n>");
+      int Precision = scn.nextInt(); //Precision for eg - 3 in 2.564 and 5 in 3.80870.
+      scn.close();
+      System.out.println(squareRoot(Number, Precision));
    }
    
-   public static double squareRoot(int N, int P) {
+   public static double squareRoot(int Number, int Precision) {
         double rv = 0;  //rv means return value
 	   
-        double root = Math.pow(N, 0.5);
+        double root = Math.pow(Number, 0.5);
 	
 	//calculate precision to power of 10 and then multiply it with root value.
-	int precision = (int) Math.pow(10, P);
+	int precision = (int) Math.pow(10, Precision);
 	root = root * precision;
 	 /*typecast it into integer then divide by precision and again typecast into double 
 	   so as to have decimal points upto P precision */ 


### PR DESCRIPTION
- I wasn't able to access the link "http://devmag.org.za/2009/04/25/perlin-noise/"  the website says "Forbidden". Added a new link for Wikipedia that describes the algorithm. I left the original link there as I'm assuming the "Forbidden" might have something to do with region. If others cannot access it either then I recommend removal of the original link (aka http://devmag.org.za/2009/04/25/perlin-noise/).
- "Scanner in"  was opened, but never closed. Now it's closed properly.