### PR TITLE
Cast the second operand of Math.pow to double - SonarQube analysis

### DIFF
--- a/src/main/java/com/crypto/codec/Base64.java
+++ b/src/main/java/com/crypto/codec/Base64.java
@@ -184,7 +184,7 @@ public class Base64 {
 
         decodedBlock[0] = (byte) (decodeAlphabet[block[0]] << 2 | decodeAlphabet[block[1]] >>> 4);
         decodedBlock[1] = (byte) (decodeAlphabet[block[1]] << 4 | decodeAlphabet[block[2]] >>> 2);
-        decodedBlock[2] = (byte) (decodeAlphabet[block[2]] << 6 | decodeAlphabet[block[3]]);
+        decodedBlock[2] = (byte) (decodeAlphabet[block[2]] << 6 | decodeAlphabet[block[3]] & 0xff);
 
         return decodedBlock;
     }

--- a/src/main/java/com/generation/SimplexNoise.java
+++ b/src/main/java/com/generation/SimplexNoise.java
@@ -36,7 +36,7 @@ public class SimplexNoise {
 
             this.octaves[index] = new SimplexNoiseOctave(random.nextInt());
             this.frequencys[index] = Math.pow(2, index);
-            this.amplitudes[index] = Math.pow(persistence, octaveCount - index);
+            this.amplitudes[index] = Math.pow(persistence, (double)octaveCount - index);
         }
     }
 
@@ -103,7 +103,7 @@ public class SimplexNoise {
         for (int index = 0; index < this.octaves.length; index++) {
 
             double frequency = Math.pow(2, index);
-            double amplitude = Math.pow(this.persistance, this.octaves.length - index);
+            double amplitude = Math.pow(this.persistance, (double)this.octaves.length - index);
 
             result += this.octaves[index].noise(x / frequency, y / frequency, z / frequency) * amplitude;
         }

--- a/src/test/java/com/generation/SimplexNoiseTest.java
+++ b/src/test/java/com/generation/SimplexNoiseTest.java
@@ -1,7 +1,5 @@
 package src.test.java.com.generation;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
@@ -9,42 +7,43 @@ import java.io.InputStream;
 
 import javax.imageio.ImageIO;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 import src.main.java.com.generation.SimplexNoise;
 
 public class SimplexNoiseTest {
 
-	@Test
-	public void testGenerateHeightMap() {
-		
-		final int WIDTH = 256;
-		final int HEIGHT = 256;
-		final int X = 0;
-		final int Y = 0;
-		final String RESOURCE_NAME = "src/test/java/com/generation/expected-result.png";
-		
-		float[][] heightmap = new SimplexNoise(50, 0.3F, 1111111111111111L).generateHeightMap(X, Y, WIDTH, HEIGHT);
-		BufferedImage image = null;
-		
-		try(InputStream in = this.getClass().getClassLoader().getResourceAsStream(RESOURCE_NAME)) {
-			
-			image = ImageIO.read(in);
-			
-			assertEquals(WIDTH, image.getWidth());
-			assertEquals(HEIGHT, image.getHeight());
-			
-		} catch(IOException | IllegalArgumentException exception) {
-			
-			fail(exception);
-		} 
-		
-		for(int x = 0; x < WIDTH; x++) {
-			
-			for(int y = 0; y < HEIGHT; y++) {
-				
-				assertEquals(new Color(image.getRGB(x, y)).getRed(), (int)(heightmap[x][y] * 255));
-			}
-		}
-	}
+    @Test
+    public void testGenerateHeightMap() {
+
+        final int WIDTH = 256;
+        final int HEIGHT = 256;
+        final int X = 0;
+        final int Y = 0;
+        final String RESOURCE_NAME = "src/test/java/com/generation/expected-result.png";
+
+        float[][] heightmap = new SimplexNoise(50, 0.3F, 1111111111111111L).generateHeightMap(X, Y, WIDTH, HEIGHT);
+        BufferedImage image = null;
+
+        try (InputStream in = this.getClass().getClassLoader().getResourceAsStream(RESOURCE_NAME)) {
+
+            image = ImageIO.read(in);
+
+            Assert.assertEquals(WIDTH, image.getWidth());
+            Assert.assertEquals(HEIGHT, image.getHeight());
+
+        } catch (IOException | IllegalArgumentException exception) {
+
+            Assert.fail(exception.toString());
+        }
+
+        for (int x = 0; x < WIDTH; x++) {
+
+            for (int y = 0; y < HEIGHT; y++) {
+
+                Assert.assertEquals(new Color(image.getRGB(x, y)).getRed(), (int) (heightmap[x][y] * 255));
+            }
+        }
+    }
 }


### PR DESCRIPTION
SonarQube showed these calls as probable minor bugs. Since Math.pow() accepts double type operands, the second operand should be type-casted explicitly for safety. 