### PR TITLE
Enable `./gradlew test`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,14 @@ repositories {
 }
 
 dependencies {
-    testCompile 'org.junit.jupiter:junit-jupiter-api:5.5.0'
+    testImplementation('org.junit.jupiter:junit-jupiter:5.5.0')
+}
+
+test {
+    useJUnitPlatform()
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 group = 'algorithm'


### PR DESCRIPTION
This commit enables `./gradlew test` to return all tests from console.

This configuration is taken from [official sample project](https://github.com/junit-team/junit5-samples/tree/r5.5.0/junit5-jupiter-starter-gradle)