### PR TITLE
Fix race condition in SingletonTest

### DIFF
--- a/src/test/java/com/designpatterns/creational/singleton/SingletonTest.java
+++ b/src/test/java/com/designpatterns/creational/singleton/SingletonTest.java
@@ -3,17 +3,17 @@ package com.designpatterns.creational.singleton;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 class SingletonTest {
-    private static volatile ArrayList<Integer> hashCodeList = new ArrayList<>();
+    private static Set<Integer> hashCodeSet = new ConcurrentSkipListSet<>();
 
     @Test
     void testSingleton() throws InterruptedException {
-        boolean testFailed = false;
         ExecutorService es = Executors.newCachedThreadPool();
         // Creates 15 threads and makes all of them access the Singleton class
         // Saves the hash code of the object in a static list
@@ -22,7 +22,7 @@ class SingletonTest {
                 try {
                     Singleton singletonInstance = Singleton.getInstance();
                     int singletonInsCode = singletonInstance.hashCode();
-                    hashCodeList.add(singletonInsCode);
+                    hashCodeSet.add(singletonInsCode);
                 } catch (Exception e) {
                     System.out.println("Exception is caught");
                 }
@@ -30,14 +30,7 @@ class SingletonTest {
         es.shutdown();
         boolean finished = es.awaitTermination(1, TimeUnit.MINUTES);
         // wait for all threads to finish
-        if (finished) {
-            Integer firstCode = hashCodeList.get(0);
-            for (Integer code : hashCodeList) {
-                if (!firstCode.equals(code)) {
-                    testFailed = true;
-                }
-            }
-            Assertions.assertFalse(testFailed);
-        }
+        Assertions.assertTrue(finished);
+        Assertions.assertEquals(1, hashCodeSet.size());
     }
 }


### PR DESCRIPTION
Because `hashCodeList` is not written as thread safe,
it may throw NullPointerException randomly
if you executes the test many times.

This commit prevents the failure with concurrent collection.