### PR TITLE
Check for integer overflow when converting between bases

### DIFF
--- a/Conversions/AnyBaseToAnyBase.java
+++ b/Conversions/AnyBaseToAnyBase.java
@@ -103,9 +103,16 @@ public class AnyBaseToAnyBase {
                 // Else, store the integer value in charB2
             else
                 charB2 = charB1 - '0';
+
             // Convert the digit to decimal and add it to the
-            // decimalValue of n
-            decimalValue = decimalValue * b1 + charB2;
+            // decimalValue of n, check if integer overflow occurs
+            long result = (long)decimalValue * b1 + charB2;
+            if (result != (int)result) {
+                // Overflow has occurred
+                throw new ArithmeticException("Integer overflow occurred");
+            }
+
+            decimalValue = (int)result;
         }
 
         // Converting the decimal value to base b2:

--- a/Searches/BinarySearch.java
+++ b/Searches/BinarySearch.java
@@ -79,7 +79,7 @@ class BinarySearch implements SearchAlgorithm {
 
 
         // The element that should be found
-        int shouldBeFound = integers[r.nextInt(size - 1)];
+        int shouldBeFound = integers[r.nextInt(size)];
 
         BinarySearch search = new BinarySearch();
         int atIndex = search.find(integers, shouldBeFound);


### PR DESCRIPTION
When converting from a larger base to a smaller one, it's possible for integer overflow to occur.