### PR TITLE
Fix off-by-one error when selecting binary search target element

### DIFF
--- a/Searches/BinarySearch.java
+++ b/Searches/BinarySearch.java
@@ -79,7 +79,7 @@ class BinarySearch implements SearchAlgorithm {
 
 
         // The element that should be found
-        int shouldBeFound = integers[r.nextInt(size - 1)];
+        int shouldBeFound = integers[r.nextInt(size)];
 
         BinarySearch search = new BinarySearch();
         int atIndex = search.find(integers, shouldBeFound);


### PR DESCRIPTION
Currently random.nextInt(arraySize - 1) is used to select a random index in the integer array to be searched. However the nextInt() bound is exclusive, so this will fail if the array only has one element.