### PR TITLE
Update SinglyLinkedList.java

### DIFF
--- a/DataStructures/Lists/SinglyLinkedList.java
+++ b/DataStructures/Lists/SinglyLinkedList.java
@@ -121,8 +121,8 @@ public class SinglyLinkedList {
         }
 
         Node destroy = cur.next;
-        cur.next = cur.next.next;
-        destroy = null; // clear to let GC do its work
+        cur.next = destroy.next;
+        destroy.next = null;
 
         size--;
     }


### PR DESCRIPTION
The original implementation has a potential memory leak problem because there is an implicit reference after `destroy = null;`.