### PR TITLE
Fixing 'Generics' issue in Sort

### DIFF
--- a/src/main/java/com/sorts/BubbleSort.java
+++ b/src/main/java/com/sorts/BubbleSort.java
@@ -2,7 +2,7 @@ package com.sorts;
 
 import com.types.Sort;
 
-public class BubbleSort<T> implements Sort<T> {
+public class BubbleSort<T extends Comparable<T>> implements Sort<T> {
   /**
    * This method implements the Generic Bubble Sort
    *
@@ -11,7 +11,7 @@ public class BubbleSort<T> implements Sort<T> {
    **/
 
   @Override
-  public <T extends Comparable<T>> T[] sort(T[] array) {
+  public T[] sort(T[] array) {
     int last = array.length;
     //Sorting
     boolean swap;

--- a/src/main/java/com/types/DataStructure.java
+++ b/src/main/java/com/types/DataStructure.java
@@ -3,7 +3,7 @@ package com.types;
 import java.util.Iterator;
 
 /**
- * This interface is to define bacis functionality expected out of any implementation class
+ * This interface is to define basic functionality expected out of any implementation class
  * Since this is a data structure it should have the flexibility to contain any kind of object hence it has been made generic
  * Any implementation class need not to be thread safe or it could be depending on the implementation class how does it want to behave.
  *

--- a/src/main/java/com/types/Sort.java
+++ b/src/main/java/com/types/Sort.java
@@ -1,7 +1,7 @@
 package com.types;
 
 @FunctionalInterface
-public interface Sort<T> {
+public interface Sort<T extends Comparable<T>> {
 
-    <T extends Comparable<T>> T[] sort(T[] array);
+    T[] sort(T[] array);
 }

--- a/src/test/java/com/sorts/BubbleSortTest.java
+++ b/src/test/java/com/sorts/BubbleSortTest.java
@@ -6,17 +6,32 @@ import org.junit.jupiter.api.Test;
 class BubbleSortTest {
 
     @Test
-    void bubbleSortTest() {
-        BubbleSort bubbleSort = new BubbleSort();
+    void bubbleSortTestIntegers() {
+        BubbleSort<Integer> bubbleSort = new BubbleSort<>();
 
-        Integer[] unsortedInt = new Integer[]{0, 5, 9, 2, 1, 3, 4, 8, 6, 7};
-        Integer[] sortedInt = new Integer[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        Integer[] unsortedInt = {0, 5, 9, 2, 1, 3, 4, 8, 6, 7};
+        Integer[] sortedInt = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         Assertions.assertArrayEquals(sortedInt, bubbleSort.sort(unsortedInt));
 
-        Character[] unsortedChar = new Character[]{'f', 'h', 'c', 'a', 'b', 'd', 'g', 'e'};
-        Character[] sortedChar = new Character[]{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
+    }
+
+    @Test
+    void bubbleSortTestCharacters() {
+        BubbleSort<Character> bubbleSort = new BubbleSort<>();
+
+        Character[] unsortedChar = {'f', 'h', 'c', 'a', 'b', 'd', 'g', 'e'};
+        Character[] sortedChar = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
         Assertions.assertArrayEquals(sortedChar, bubbleSort.sort(unsortedChar));
 
     }
 
+    @Test
+    void bubbleSortTestStrings() {
+        BubbleSort<String> bubbleSort = new BubbleSort<>();
+
+        String[] unsortedChar = {"abc", "adc", "bcd", "abb", "abc", "acb"};
+        String[] sortedChar = {"abb", "abc", "abc", "acb", "adc", "bcd"};
+        Assertions.assertArrayEquals(sortedChar, bubbleSort.sort(unsortedChar));
+
+    }
 }


### PR DESCRIPTION
Fixed 'Generics' issue of bubble sort since Sort interface should accept only comparable datatype rather than just restricting sort method