### PR TITLE
Change wrong explantation in javadoc

### DIFF
--- a/Sorts/BubbleSort.java
+++ b/Sorts/BubbleSort.java
@@ -13,7 +13,7 @@ class BubbleSort implements SortAlgorithm {
      * This method implements the Generic Bubble Sort
      *
      * @param array The array to be sorted
-     *              Sorts the array in increasing order
+     *              Sorts the array in descending order
      **/
 
     @Override


### PR DESCRIPTION
In this file, The sorting is happened by "descending order" not "increasing
order". 
And I think it would be better if the sorting is implemented as "ascending order" 
like most of sorts in this repo are. 