### PR TITLE
Fixed code smells after running sonarqube on the project

### DIFF
--- a/src/main/java/com/caching/LFUCache.java
+++ b/src/main/java/com/caching/LFUCache.java
@@ -75,8 +75,8 @@ class LFUCache<T> {
     public LFUCache(int capacity) {
         this.capacity = capacity;
         size = 0;
-        freq = new TreeMap<Integer, DLL>();
-        map = new HashMap<Integer, Node>();
+        freq = new TreeMap<>();
+        map = new HashMap<>();
         System.out.println("LFUCache initialised with capacity: " + capacity);
     }
 
@@ -145,8 +145,8 @@ class LFUCache<T> {
                 dll.deleteNode(dll.tail.pre);
                 if (dll.len == 0 && lowest != 1)
                     freq.remove(lowest);
-                DLL freq_one = freq.computeIfAbsent(1, k -> new DLL());
-                freq_one.addToHead(node);
+                DLL freqOne = freq.computeIfAbsent(1, k -> new DLL());
+                freqOne.addToHead(node);
             }
         }
 

--- a/src/main/java/com/caching/LRUCache.java
+++ b/src/main/java/com/caching/LRUCache.java
@@ -63,7 +63,6 @@ public class LRUCache<T> {
             System.out.println("Cache set to 0 capacity. No elements will be cached");
         }
 
-        T currentValue = cache.get(key);
         if (!cache.containsKey(key)) {
             cache.put(key, value);
             System.out.println("Adding new key:" + key + " to cache");

--- a/src/main/java/com/ciphers/CaesarBruteForce.java
+++ b/src/main/java/com/ciphers/CaesarBruteForce.java
@@ -5,25 +5,25 @@ public class CaesarBruteForce {
     /**
      * Recursively Brute forces a parsed encrypted text, trying out all shifting keys from 1-26, printing out all decryption attempts
      * @param message (String) The encrypted text.
-     * @param Key (int) The key used to decrypt the encrypted text and is increment upon a recursive call.
+     * @param key (int) The key used to decrypt the encrypted text and is increment upon a recursive call.
      * @return (String) Concatenated string of all decryption attempts (For unit testing purposes).
      */
-    public String decrypt(String message, int Key) {
+    public String decrypt(String message, int key) {
         final String LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-        if (Key > 26){ System.out.println(); return null; }
+        if (key > 26){ System.out.println(); return null; }
 
         StringBuilder plainText = new StringBuilder();
         for (char character : message.toUpperCase().toCharArray()) {
             int index = LETTERS.indexOf(character);
 
             if (index != -1) {
-                index -= Key;
+                index -= key;
                 //Wrap around index value range[1-26]
                 if (index < 0) { index += LETTERS.length(); }
                 plainText.append(LETTERS.toCharArray()[index]);
             } else { plainText.append(character); }
         }
-        System.out.println(String.format("Current Decryption Key %d : %s", Key, plainText));
-        return plainText.append(decrypt(message, Key+1)).toString();
+        System.out.println(String.format("Current Decryption Key %d : %s", key, plainText));
+        return plainText.append(decrypt(message, key+1)).toString();
     }
 }

--- a/src/main/java/com/conversions/HexadecimalToBinary.java
+++ b/src/main/java/com/conversions/HexadecimalToBinary.java
@@ -12,7 +12,7 @@ public class HexadecimalToBinary {
 	public String hexToBin (String hexStr) {
 		
 		String binaryString = "", hexaNumbers = "0123456789ABCDEF", 
-				DecimalStr ="", binaryStringBefore ="" , binaryStringAfter = "";
+				decimalStr ="", binaryStringBefore ="" , binaryStringAfter = "";
 		int indexOfHex, decimalNumber = 0, k = 1, n =1, z=1, decimalNumberBefore = 0
 				, decimalNumberAfter = 0;
 		char letter;
@@ -48,12 +48,12 @@ public class HexadecimalToBinary {
 
 			String decimalNumberAfterStr = String.valueOf(decimalNumberAfter);
 			
-			DecimalStr = decimalNumberBeforeStr + '.' + decimalNumberAfterStr;
+			decimalStr = decimalNumberBeforeStr + '.' + decimalNumberAfterStr;
 			}
 
 		
 		
-		int pointPositionDec = DecimalStr.indexOf(".");
+		int pointPositionDec = decimalStr.indexOf(".");
 		/**
 		 * Check whether the result contains a floating point or not
 		 */

--- a/src/main/java/com/datastructures/BinaryTree.java
+++ b/src/main/java/com/datastructures/BinaryTree.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 /**
  * Binary tree for general value type, without redundancy

--- a/src/main/java/com/datastructures/BinaryTree.java
+++ b/src/main/java/com/datastructures/BinaryTree.java
@@ -8,7 +8,7 @@ package com.datastructures;
 
 public class BinaryTree<T extends Comparable> {
     private final T data;
-    private BinaryTree right,  // the upper binary tree
+    private BinaryTree<T> right,  // the upper binary tree
             left;   // the lower binary tree
 
     public BinaryTree(T data) {
@@ -21,35 +21,38 @@ public class BinaryTree<T extends Comparable> {
     }
 
     /**
-     * inserts a new value in it's correspondant place
+     * inserts a new value in it's correspondent place
      *
      * @param newDataValue value of the new binary tree to add on this tree
      */
     public void insert(T newDataValue) {
-        this.insert(new BinaryTree(newDataValue));
+        this.insert(new BinaryTree<>(newDataValue));
     }
 
     /**
-     * inserts a new binary tree in it's correspondant place
+     * inserts a new binary tree in it's correspondent place
      *
      * @param newData new value to add on this tree
      */
-    public void insert(BinaryTree newData) {
+    public void insert(BinaryTree<T> newData) {
 
         int cpr = newData.data.compareTo(this.data); //new value comparission respect to actual value
 
-        if (cpr < 0)
-            if (this.left == null)
+        if (cpr < 0) {
+            if (this.left == null) {
                 this.setLeft(newData);
-            else
+            } else {
                 this.left.insert(newData);
-        else if (cpr > 0)
-            if (this.right == null)
+            }
+        } else if (cpr > 0) {
+            if (this.right == null) {
                 this.setRight(newData);
-            else
+            } else {
                 this.right.insert(newData);
-        else
+            }
+        } else {
             System.out.println("Redundant value, not added");
+        }
     }
 
     /**
@@ -58,8 +61,8 @@ public class BinaryTree<T extends Comparable> {
      * @param data Searched value
      * @return Binary tree which contains the value, null if it doesn't exist
      */
-    public BinaryTree search(T data) {
-        int cpr = data.compareTo(this.data); //new value comparission respect to actual value
+    public BinaryTree<T> search(T data) {
+        int cpr = data.compareTo(this.data); //new value comparison respect to actual value
 
         if (cpr < 0) {
             if (this.left == null)
@@ -113,19 +116,19 @@ public class BinaryTree<T extends Comparable> {
         return data;
     }
 
-    public BinaryTree getRight() {
+    public BinaryTree<T> getRight() {
         return right;
     }
 
-    public void setRight(BinaryTree right) {
+    public void setRight(BinaryTree<T> right) {
         this.right = right;
     }
 
-    public BinaryTree getLeft() {
+    public BinaryTree<T> getLeft() {
         return left;
     }
 
-    public void setLeft(BinaryTree left) {
+    public void setLeft(BinaryTree<T> left) {
         this.left = left;
     }
 }

--- a/src/main/java/com/datastructures/DisjointSet.java
+++ b/src/main/java/com/datastructures/DisjointSet.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 import java.io.Serializable;
 import java.util.*;

--- a/src/main/java/com/datastructures/DisjointSet.java
+++ b/src/main/java/com/datastructures/DisjointSet.java
@@ -18,14 +18,15 @@ import java.util.*;
  */
 public class DisjointSet<T> implements Serializable {
     private static final long serialVersionUID = 3134700471905625636L;
+    private static final String elementKey = "element";
 
-    private Map<T, Node<T>> nodeMap = new HashMap<>();
+    private final Map<T, Node<T>> nodeMap = new HashMap<>();
 
     /**
      * Add an element to the disjoint-set forests as a set.
      */
     public void makeSet(T element) {
-        checkNotNull(element, "element");
+        checkNotNull(element, elementKey);
         nodeMap.putIfAbsent(element, new Node<>());
     }
 
@@ -36,8 +37,8 @@ public class DisjointSet<T> implements Serializable {
      * Rank is an upper bound on the height of node.
      */
     public void union(T left, T right) {
-        checkNotNull(left, "element");
-        checkNotNull(right, "element");
+        checkNotNull(left, elementKey);
+        checkNotNull(right, elementKey);
 
         Node<T> leftNode = nodeMap.get(left),
                 rightNode = nodeMap.get(right);

--- a/src/main/java/com/datastructures/GeneralQueue.java
+++ b/src/main/java/com/datastructures/GeneralQueue.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 import com.types.Queue;
 

--- a/src/main/java/com/datastructures/IntQueue.java
+++ b/src/main/java/com/datastructures/IntQueue.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 /**
  * This file contains an implementation of an integer only queue which is extremely quick and

--- a/src/main/java/com/datastructures/SinglyLinkedList.java
+++ b/src/main/java/com/datastructures/SinglyLinkedList.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 
 

--- a/src/main/java/com/datastructures/Stack.java
+++ b/src/main/java/com/datastructures/Stack.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 import java.io.Serializable;
 import java.util.EmptyStackException;

--- a/src/main/java/com/matchings/stablematching/GaleShapley.java
+++ b/src/main/java/com/matchings/stablematching/GaleShapley.java
@@ -1,4 +1,4 @@
-package com.matchings.stableMatching;
+package com.matchings.stablematching;
 
 public class GaleShapley {
 

--- a/src/test/java/com/datastructures/BinaryTreeTest.java
+++ b/src/test/java/com/datastructures/BinaryTreeTest.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/datastructures/DisjointSetTest.java
+++ b/src/test/java/com/datastructures/DisjointSetTest.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/datastructures/GeneralQueueTest.java
+++ b/src/test/java/com/datastructures/GeneralQueueTest.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 
 import com.types.Queue;

--- a/src/test/java/com/datastructures/IntQueueTest.java
+++ b/src/test/java/com/datastructures/IntQueueTest.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/com/datastructures/SinglyLinkedListTest.java
+++ b/src/test/java/com/datastructures/SinglyLinkedListTest.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;

--- a/src/test/java/com/datastructures/StackTest.java
+++ b/src/test/java/com/datastructures/StackTest.java
@@ -1,4 +1,4 @@
-package com.dataStructures;
+package com.datastructures;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/matchings/stablematching/GaleShapleyTest.java
+++ b/src/test/java/com/matchings/stablematching/GaleShapleyTest.java
@@ -1,4 +1,4 @@
-package com.matchings.stableMatching;
+package com.matchings.stablematching;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Multiple code smells were found by [SonarQube](https://www.sonarqube.org/) on the project. Some of them were violations of the below rules:

- Local variable names in java must be with the  default regular expression ^[a-z][a-zA-Z0-9]*$ [RSPEC-117](https://rules.sonarsource.com/java/tag/convention/RSPEC-117)
- The diamond operator ("<>") should be used when the type of the maps are already defined [RSPEC-2293](https://rules.sonarsource.com/java/RSPEC-2293)
- Package names being camel cased is a code smell, all package names must be lowercase
- String literals should not be duplicated [RSPEC-1192](https://rules.sonarsource.com/java/RSPEC-1192)
- Generic types shouldn't be used raw (without type parameters) in variable declarations or return values. Doing so bypasses generic type checking, and defers the catch of unsafe code to runtime. [RSPEC-3740](https://rules.sonarsource.com/java/RSPEC-3740)
- The dangling else problem appears when nested if/else statements are written without curly braces. In this case, else is associated with the nearest if but that is not always obvious and sometimes the indentation can also be misleading.[RSPEC-5261](https://rules.sonarsource.com/java/tag/confusing/RSPEC-5261)

Here is the overall SonarQube report for the repo (Development) branch post the fixes.

![image](https://user-images.githubusercontent.com/51189926/90881751-6c68e700-e3c8-11ea-901c-4b5fca9449c4.png)

This pull request brings down the code smells from 188 to 177.
