### PR TITLE
Fix 2D array passed to Arrays.fill()

### DIFF
--- a/DataStructures/Graphs/FloydWarshall.java
+++ b/DataStructures/Graphs/FloydWarshall.java
@@ -14,7 +14,7 @@ public class FloydWarshall {
             [numberofvertices
                 + 1]; // stores the value of distance from all the possible path form the source
     // vertex to destination vertex
-    Arrays.fill(DistanceMatrix, 0);
+    // The matrix is initialized with 0's by default
     this.numberofvertices = numberofvertices;
   }
 


### PR DESCRIPTION
Arrays.fill() accepts single dimensional arrays, so fill one row at a time.

Fixes TheAlgorithms/Java#2009


### **Describe your change:**

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

#### References

<!-- Add any reference to previous pull-request or issue -->

### **Checklist:**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new Java files are placed inside an existing directory.
- [x] All filenames are in all uppercase characters with no spaces or dashes.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
