### PR TITLE
Changed Queue.peekFront() to return front.data not front.next.data

### DIFF
--- a/DataStructures/Queues/LinkedQueue.java
+++ b/DataStructures/Queues/LinkedQueue.java
@@ -89,7 +89,7 @@ public class LinkedQueue {
     if (isEmpty()) {
       throw new NoSuchElementException("queue is empty");
     }
-    return front.next.data;
+    return front.data;
   }
 
   /**


### PR DESCRIPTION
### **Describe your change:**

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

#### References

<!-- Add any reference to previous pull-request or issue -->

### **Checklist:**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new Java files are placed inside an existing directory.
- [x] All filenames are in all uppercase characters with no spaces or dashes.
- [x] All functions and variable names follow Java naming conventions.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.

/Java/DataStructures/Queues/LinkedQueue
Implementation of peekFront() doesn't match it's documented description.
It is described as if it returns the first element without removing it, however, it returns the second element (front.next.data)

