### PR TITLE
improve knapsack code: the array rw contains zeros right after it is created by new.

### DIFF
--- a/DynamicProgramming/Knapsack.java
+++ b/DynamicProgramming/Knapsack.java
@@ -11,9 +11,8 @@ public class Knapsack {
     // Build table rv[][] in bottom up manner
     for (i = 0; i < n; i++) {
       for (w = 0; w <= W; w++) {
-        if (wt[i] <= w)
-          rv[i+1][w] = Math.max(val[i] + rv[i][w - wt[i]], rv[i][w]);
-        else rv[i+1][w] = rv[i][w];
+        if (wt[i] <= w) rv[i + 1][w] = Math.max(val[i] + rv[i][w - wt[i]], rv[i][w]);
+        else rv[i + 1][w] = rv[i][w];
       }
     }
 

--- a/DynamicProgramming/Knapsack.java
+++ b/DynamicProgramming/Knapsack.java
@@ -9,12 +9,11 @@ public class Knapsack {
     int rv[][] = new int[n + 1][W + 1]; // rv means return value
 
     // Build table rv[][] in bottom up manner
-    for (i = 0; i <= n; i++) {
+    for (i = 0; i < n; i++) {
       for (w = 0; w <= W; w++) {
-        if (i == 0 || w == 0) rv[i][w] = 0;
-        else if (wt[i - 1] <= w)
-          rv[i][w] = Math.max(val[i - 1] + rv[i - 1][w - wt[i - 1]], rv[i - 1][w]);
-        else rv[i][w] = rv[i - 1][w];
+        if (wt[i] <= w)
+          rv[i+1][w] = Math.max(val[i] + rv[i][w - wt[i]], rv[i][w]);
+        else rv[i+1][w] = rv[i][w];
       }
     }
 


### PR DESCRIPTION
### **Describe your change:**

- [ ] Add an algorithm?
- [x] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

When we create an array of something, all entries are also zeroed. So the array `rw`  contains zeros right after it is created by new. It is not necessary to set them in the loop.

#### References


### **Checklist:**

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized.
- [x] I know that pull requests will not be merged if they fail the automated tests.
- [x] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [x] All new Java files are placed inside an existing directory.
- [x] All filenames are in all uppercase characters with no spaces or dashes.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanation.
- [x] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
