### PR TITLE
Update MinHeap.java

### DIFF
--- a/src/main/java/com/thealgorithms/datastructures/heaps/MinHeap.java
+++ b/src/main/java/com/thealgorithms/datastructures/heaps/MinHeap.java
@@ -50,7 +50,7 @@ public class MinHeap implements Heap {
     // Toggle an element up to its right place as long as its key is lower than its parent's
     private void toggleUp(int elementIndex) {
         double key = minHeap.get(elementIndex - 1).getKey();
-        while (getElementKey((int) Math.floor(elementIndex / 2.0)) > key) {
+        while (getElementKey((int) Math.floor(elementIndex / 2.0) + 1) > key) {
             swap(elementIndex, (int) Math.floor(elementIndex / 2.0));
             elementIndex = (int) Math.floor(elementIndex / 2.0);
         }


### PR DESCRIPTION
getElementKey method is decreasing the value of elementIndex by 1, so we can either add +1 while calling toggleUp or avoid decreasing the value of elementIndex.

### **Describe your change:**

- [ ] Add an algorithm?
- [X] Fix a bug or typo in an existing algorithm?
- [ ] Documentation change?

#### References

[GitHub Issue](https://github.com/TheAlgorithms/Java/issues/3158)

### **Checklist:**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [X] This pull request is all my own work -- I have not plagiarized.
- [X] I know that pull requests will not be merged if they fail the automated tests.
- [X] This PR only changes one algorithm file. To ease review, please open separate PRs for separate algorithms.
- [X] All new Java files are placed inside an existing directory.
- [X] All filenames are in all uppercase characters with no spaces or dashes.
- [X] All functions and variable names follow Java naming conventions.
- [X] All new algorithms have a URL in its comments that points to Wikipedia or other similar explanation.
- [X] If this pull request resolves one or more open issues then the commit message contains `Fixes: #{$ISSUE_NO}`.
