### PR TITLE
Python 3.11 is between 10-60% faster than Python 3.10

### DIFF
--- a/.github/workflows/update_directory.yml
+++ b/.github/workflows/update_directory.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.x'
       - name: Update Directory
         shell: python
         run: |


### PR DESCRIPTION
A simple fix to accelerate our GitHub Actions...

https://docs.python.org/3.11/whatsnew/3.11.html
> Python 3.11 is between 10-60% faster than Python 3.10. On average, we measured a 1.25x speedup on the standard benchmark suite.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.

@Boiarshinov Your review, please.