### PR TITLE
fix: handle empty input for `GCD.gcd(int[])`

### DIFF
--- a/src/main/java/com/thealgorithms/maths/GCD.java
+++ b/src/main/java/com/thealgorithms/maths/GCD.java
@@ -35,13 +35,13 @@ public class GCD {
     /**
      * get greatest common divisor in array
      *
-     * @param number contains number
+     * @param numbers contains numbers
      * @return gcd
      */
-    public static int gcd(int[] number) {
-        int result = number[0];
-        for (int i = 1; i < number.length; i++) { // call gcd function (input two value)
-            result = gcd(result, number[i]);
+    public static int gcd(int[] numbers) {
+        int result = 0;
+        for (final var number : numbers) {
+            result = gcd(result, number);
         }
 
         return result;

--- a/src/main/java/com/thealgorithms/maths/GCD.java
+++ b/src/main/java/com/thealgorithms/maths/GCD.java
@@ -33,10 +33,10 @@ public class GCD {
     }
 
     /**
-     * get greatest common divisor in array
+     * @brief computes gcd of an array of numbers
      *
-     * @param numbers contains numbers
-     * @return gcd
+     * @param numbers the input array
+     * @return gcd of all of the numbers in the input array
      */
     public static int gcd(int[] numbers) {
         int result = 0;

--- a/src/test/java/com/thealgorithms/maths/GCDTest.java
+++ b/src/test/java/com/thealgorithms/maths/GCDTest.java
@@ -48,4 +48,14 @@ public class GCDTest {
     void test7() {
         Assertions.assertEquals(GCD.gcd(9, 6), 3);
     }
+    
+    @Test
+    void testArrayGcd1() {
+        Assertions.assertEquals(GCD.gcd(new int[]{9, 6}), 3);
+    }
+
+    @Test
+    void testArrayGcd2() {
+        Assertions.assertEquals(GCD.gcd(new int[]{2*3*5*7, 2*5*5*5, 2*5*11, 5*5*5*13}), 5);
+    }
 }

--- a/src/test/java/com/thealgorithms/maths/GCDTest.java
+++ b/src/test/java/com/thealgorithms/maths/GCDTest.java
@@ -58,4 +58,9 @@ public class GCDTest {
     void testArrayGcd2() {
         Assertions.assertEquals(GCD.gcd(new int[]{2*3*5*7, 2*5*5*5, 2*5*11, 5*5*5*13}), 5);
     }
+    
+    @Test
+    void testArrayGcdForEmptyInput() {
+        Assertions.assertEquals(GCD.gcd(new int[]{}), 0);
+    }    
 }


### PR DESCRIPTION
I have observed that the function [`GCD.gcd(int[])`](https://github.com/TheAlgorithms/Java/blob/36232a8373264319cdb893bf9da1615fea05999d/src/main/java/com/thealgorithms/maths/GCD.java#L41):
- is not tested,
- crashes when computing `GCD.gcd(new int[]{});`,
- `GCD.gcd(new int[]{-1});` returns `-1` (observe that GCD.gcd(-1, -1); [would throw](https://github.com/TheAlgorithms/Java/blob/36232a8373264319cdb893bf9da1615fea05999d/src/main/java/com/thealgorithms/maths/GCD.java#L20) `ArithmeticException()`).

In this PR, I:
- add missing tests 7e60a58be3ac3ec5de2c46bd28e5ae42b1f1e57e,
- make `GCD.gcd(new int[]{});` returns `0` a6b5d09bbf424d7cc142390ccf51c11088edc288 - this change also handles the case, when the input is of the type `{-1}`,
- update documentation 9d0c20d995731f4d36aaf7bcf8358724a0fe070f

I allowed myself not to create an issue for such a _small_ thing. I hope it is not a big problem.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
