### PR TITLE
style: handle empty input array in `FindMax.findMax`

### DIFF
--- a/src/main/java/com/thealgorithms/maths/FindMax.java
+++ b/src/main/java/com/thealgorithms/maths/FindMax.java
@@ -24,16 +24,20 @@ public class FindMax {
     }
 
     /**
-     * find max of array
+     * @brief finds the maximum value stored in the input array
      *
-     * @param array the array contains element
-     * @return max value of given array
+     * @param array the input array
+     * @exception IllegalArgumentException input array is empty
+     * @return the maximum value stored in the input array
      */
     public static int findMax(int[] array) {
-        int max = array[0];
-        for (int i = 1; i < array.length; ++i) {
-            if (array[i] > max) {
-                max = array[i];
+        if (array.length == 0) {
+            throw new IllegalArgumentException("array must be non-empty.");
+        }
+        int max = Integer.MIN_VALUE;
+        for (final var value : array) {
+            if (value > max) {
+                max = value;
             }
         }
         return max;

--- a/src/test/java/com/thealgorithms/maths/FindMaxTest.java
+++ b/src/test/java/com/thealgorithms/maths/FindMaxTest.java
@@ -7,10 +7,26 @@ import org.junit.jupiter.api.Test;
 public class FindMaxTest {
 
     @Test
-    public void testFindMaxValue() {
+    public void testFindMax0() {
         assertEquals(
             10,
             FindMax.findMax(new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 })
+        );
+    }
+
+    @Test
+    public void testFindMax1() {
+        assertEquals(
+            7,
+            FindMax.findMax(new int[] { 6, 3, 5, 1, 7, 4, 1 })
+        );
+    }
+
+    @Test
+    public void testFindMax2() {
+        assertEquals(
+            10,
+            FindMax.findMax(new int[] { 10, 0 })
         );
     }
 }

--- a/src/test/java/com/thealgorithms/maths/FindMaxTest.java
+++ b/src/test/java/com/thealgorithms/maths/FindMaxTest.java
@@ -1,6 +1,7 @@
 package com.thealgorithms.maths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +28,14 @@ public class FindMaxTest {
         assertEquals(
             10,
             FindMax.findMax(new int[] { 10, 0 })
+        );
+    }
+
+    @Test
+    public void testFindMaxThrowsExceptionForEmptyInput() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> FindMax.findMax(new int[]{})
         );
     }
 }


### PR DESCRIPTION
<!-- For completed items, change [ ] to [x] -->

This PR is analogous to #4205. The method [`FindMax.findMax`](https://github.com/TheAlgorithms/Java/blob/4f1514980495c4daaae2eb060228a87e14cbae11/src/main/java/com/thealgorithms/maths/FindMax.java#L32) crashes for empty input.

This PR:
- adds _missing_ test cases,
- makes `findMax` to throw `IllegalArgumentException` for empty input,
- updates the implementation and doc string to be consistent with [`FindMin.findMin`](https://github.com/TheAlgorithms/Java/blob/4f1514980495c4daaae2eb060228a87e14cbae11/src/main/java/com/thealgorithms/maths/FindMin.java#L33)

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
