### PR TITLE
chore: configure gitpod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,1 @@
+FROM gitpod/workspace-java-17:2023-07-20-19-56-24

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+---
+image:
+  file: .gitpod.dockerfile
+
+tasks:
+  - init: |
+      mvn dependency:resolve
+      mvn compile


### PR DESCRIPTION
When this project is opened in Gitpod, the created workspace does not directly work. This PR adds some basic configuration (i.e. now, in created workspace one can successfully run `mvn test`).

I could not force the the existing [docker image](https://github.com/TheAlgorithms/Java/blob/4effd28d80faa64087c2cbb94f106e5be61b7324/.devcontainer/Dockerfile) to work with Gitpod.

<!-- For completed items, change [ ] to [x] -->

- [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [X] This pull request is all my own work -- I have not plagiarized it.
- [X] ~~All filenames are in PascalCase.~~ (does not apply)
- [X] ~~All functions and variable names follow Java naming conventions.~~ (does not apply)
- [X] ~~All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.~~ (does not apply)
