### PR TITLE
chore: add clang-format to gitpod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,1 +1,11 @@
 FROM gitpod/workspace-java-17:2023-07-20-19-56-24
+
+USER root
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  clang-format=1:14.0-55~exp2 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+USER gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,3 +6,7 @@ tasks:
   - init: |
       mvn dependency:resolve
       mvn compile
+
+vscode:
+  extensions:
+    - xaver.clang-format


### PR DESCRIPTION
This PR allows to use clang-format in gitpod's VS Code (cf. #4214). It is a _continuation_ of #4243.

<!-- For completed items, change [ ] to [x] -->

- [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [X] This pull request is all my own work -- I have not plagiarized it.
- [X] ~~All filenames are in PascalCase.~~ (does not apply)
- [X] ~~All functions and variable names follow Java naming conventions.~~ (does not apply)
- [X] ~~All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.~~ (does not apply)
