### PR TITLE
fix: handle inputs like `"2 +"` in `StackPostfixNotation`

### DIFF
--- a/src/main/java/com/thealgorithms/others/StackPostfixNotation.java
+++ b/src/main/java/com/thealgorithms/others/StackPostfixNotation.java
@@ -16,6 +16,9 @@ public final class StackPostfixNotation {
             if (tokens.hasNextInt()) {
                 s.push(tokens.nextInt()); // If int then push to stack
             } else { // else pop top two values and perform the operation
+                if (s.size() < 2) {
+                    throw new IllegalArgumentException("exp is not a proper postfix expression (too few arguments).");
+                }
                 int num2 = s.pop();
                 int num1 = s.pop();
                 String op = tokens.next();

--- a/src/test/java/com/thealgorithms/others/StackPostfixNotationTest.java
+++ b/src/test/java/com/thealgorithms/others/StackPostfixNotationTest.java
@@ -30,4 +30,14 @@ public class StackPostfixNotationTest {
     public void testIfEvaluateThrowsExceptionForInputWithUnknownOperation() {
         assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate("3 3 !"));
     }
+
+    @Test
+    public void testIfEvaluateThrowsExceptionForInputWithTooFewArgsA() {
+        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate("+"));
+    }
+
+    @Test
+    public void testIfEvaluateThrowsExceptionForInputWithTooFewArgsB() {
+        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate("2 +"));
+    }
 }


### PR DESCRIPTION
After #4261 was merged, I have realized that the method [`StackPostfixNotation.postfixEvaluate`](https://github.com/vil02/Java/blob/44dcebb6996b39b5a1a67a8633f95b6e4c1bd0f0/src/main/java/com/thealgorithms/others/StackPostfixNotation.java#L11) still does not handle properly all of the inputs (e. g. `"2 +"` or `"+"`). This PR fixes that.


<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
