### PR TITLE
refactor: simplify `StackPostfixNotation.postfixEvaluate`

### DIFF
--- a/src/main/java/com/thealgorithms/others/StackPostfixNotation.java
+++ b/src/main/java/com/thealgorithms/others/StackPostfixNotation.java
@@ -2,38 +2,61 @@ package com.thealgorithms.others;
 
 import java.util.Scanner;
 import java.util.Stack;
+import java.util.function.BiFunction;
 
+/**
+ * @brief Utility class evaluating a postix expressions, cf. https://en.wikipedia.org/wiki/Reverse_Polish_notation
+ * @details The computation is done using Integers.
+ */
 public final class StackPostfixNotation {
     private StackPostfixNotation() {
     }
 
-    // Evaluates the given postfix expression string and returns the result.
-    public static int postfixEvaluate(final String exp) {
-        Stack<Integer> s = new Stack<Integer>();
+    private static BiFunction<Integer, Integer, Integer> getOperator(final String operationSymbol) {
+        // note the order of operands
+        switch (operationSymbol) {
+        case "+":
+            return (a, b) -> b + a;
+        case "-":
+            return (a, b) -> b - a;
+        case "*":
+            return (a, b) -> b * a;
+        case "/":
+            return (a, b) -> b / a;
+        default:
+            throw new IllegalArgumentException("exp contains an unknown operation.");
+        }
+    }
+
+    private static void performOperation(Stack<Integer> s, final String operationSymbol) {
+        if (s.size() < 2) {
+            throw new IllegalArgumentException("exp is not a proper postfix expression (too few arguments).");
+        }
+        s.push(getOperator(operationSymbol).apply(s.pop(), s.pop()));
+    }
+
+    private static void consumeExpression(Stack<Integer> s, final String exp) {
         Scanner tokens = new Scanner(exp);
 
         while (tokens.hasNext()) {
             if (tokens.hasNextInt()) {
-                s.push(tokens.nextInt()); // If int then push to stack
-            } else { // else pop top two values and perform the operation
-                if (s.size() < 2) {
-                    throw new IllegalArgumentException("exp is not a proper postfix expression (too few arguments).");
-                }
-                int num2 = s.pop();
-                int num1 = s.pop();
-                String op = tokens.next();
-
-                switch (op) {
-                    case "+" -> s.push(num1 + num2);
-                    case "-" -> s.push(num1 - num2);
-                    case "*" -> s.push(num1 * num2);
-                    case "/" -> s.push(num1 / num2);
-                    default -> throw new IllegalArgumentException("exp contains an unknown operation.");
-                }
-                //  "+", "-", "*", "/"
+                s.push(tokens.nextInt());
+            } else {
+                performOperation(s, tokens.next());
             }
         }
         tokens.close();
+    }
+
+    /**
+     * @brief Evaluates the given postfix expression.
+     * @param exp the expression to evaluate.
+     * @return the value of the given expresion.
+     * @exception IllegalArgumentException exp is not a valid postix expresion.
+     */
+    public static int postfixEvaluate(final String exp) {
+        Stack<Integer> s = new Stack<Integer>();
+        consumeExpression(s, exp);
         if (s.size() != 1) {
             throw new IllegalArgumentException("exp is not a proper postfix expression.");
         }


### PR DESCRIPTION
This PR simplifies the method [StackPostfixNotation.postfixEvaluate](https://github.com/TheAlgorithms/Java/blob/fc274c84f8f64ad4a874342736696c6293c78121/src/main/java/com/thealgorithms/others/StackPostfixNotation.java#L11) and updates the _doc-strings_ (cf. #4261). 

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
