### PR TITLE
refactor: make `Factorial` a proper utility class

### DIFF
--- a/src/main/java/com/thealgorithms/maths/Factorial.java
+++ b/src/main/java/com/thealgorithms/maths/Factorial.java
@@ -1,6 +1,9 @@
 package com.thealgorithms.maths;
 
-public class Factorial {
+public final class Factorial {
+    private Factorial() {
+    }
+
     /**
      * Calculate factorial N using iteration
      *


### PR DESCRIPTION
Following @siriak [suggestion](https://github.com/TheAlgorithms/Java/pull/4266/files#r1278050924) in #4266, I create this PR, which:
- explicitly defines the default constructor of `Factorial` as `private` - it does not make sense to create any instances of this class (because it has only static method and no members),
- marks the class `Factorial` as `final` - it does not make sense to have any class extending it.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] ~~All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.~~
