### PR TITLE
tests: add tests for `GenericRoot`

### DIFF
--- a/src/main/java/com/thealgorithms/maths/GenericRoot.java
+++ b/src/main/java/com/thealgorithms/maths/GenericRoot.java
@@ -15,7 +15,7 @@ public class GenericRoot {
         System.out.println("Generic root of " + number2 + " is: " + result2);
     }
 
-    private static int genericRoot(int n) {
+    public static int genericRoot(int n) {
         int root = 0;
         while (n > 0 || root > 9) {
             if (n == 0) {

--- a/src/main/java/com/thealgorithms/maths/GenericRoot.java
+++ b/src/main/java/com/thealgorithms/maths/GenericRoot.java
@@ -15,19 +15,21 @@ public class GenericRoot {
         System.out.println("Generic root of " + number2 + " is: " + result2);
     }
 
+    private static int sumOfDigits(int n) {
+        assert n >= 0;
+        if (n < 10) {
+            return n;
+        }
+        return n % 10 + sumOfDigits(n / 10);
+    }
+
     public static int genericRoot(int n) {
         if (n < 0) {
             return genericRoot(-n);
         }
-        int root = 0;
-        while (n > 0 || root > 9) {
-            if (n == 0) {
-                n = root;
-                root = 0;
-            }
-            root += n % 10;
-            n /= 10;
+        if (n > 10) {
+            return genericRoot(sumOfDigits(n));
         }
-        return root;
+        return n;
     }
 }

--- a/src/main/java/com/thealgorithms/maths/GenericRoot.java
+++ b/src/main/java/com/thealgorithms/maths/GenericRoot.java
@@ -8,19 +8,21 @@ public final class GenericRoot {
     private GenericRoot() {
     }
 
-    private static int sumOfDigits(int n) {
+    private static int base = 10;
+
+    private static int sumOfDigits(final int n) {
         assert n >= 0;
-        if (n < 10) {
+        if (n < base) {
             return n;
         }
-        return n % 10 + sumOfDigits(n / 10);
+        return n % base + sumOfDigits(n / base);
     }
 
-    public static int genericRoot(int n) {
+    public static int genericRoot(final int n) {
         if (n < 0) {
             return genericRoot(-n);
         }
-        if (n > 10) {
+        if (n > base) {
             return genericRoot(sumOfDigits(n));
         }
         return n;

--- a/src/main/java/com/thealgorithms/maths/GenericRoot.java
+++ b/src/main/java/com/thealgorithms/maths/GenericRoot.java
@@ -16,6 +16,9 @@ public class GenericRoot {
     }
 
     public static int genericRoot(int n) {
+        if (n < 0) {
+            return genericRoot(-n);
+        }
         int root = 0;
         while (n > 0 || root > 9) {
             if (n == 0) {

--- a/src/main/java/com/thealgorithms/maths/GenericRoot.java
+++ b/src/main/java/com/thealgorithms/maths/GenericRoot.java
@@ -4,15 +4,8 @@ package com.thealgorithms.maths;
  * Algorithm explanation:
  * https://technotip.com/6774/c-program-to-find-generic-root-of-a-number/#:~:text=Generic%20Root%3A%20of%20a%20number,get%20a%20single%2Ddigit%20output.&text=For%20Example%3A%20If%20user%20input,%2B%204%20%2B%205%20%3D%2015.
  */
-public class GenericRoot {
-
-    public static void main(String[] args) {
-        int number1 = 1234;
-        int number2 = 12345;
-        int result1 = genericRoot(number1);
-        int result2 = genericRoot(number2);
-        System.out.println("Generic root of " + number1 + " is: " + result1);
-        System.out.println("Generic root of " + number2 + " is: " + result2);
+public final class GenericRoot {
+    private GenericRoot() {
     }
 
     private static int sumOfDigits(int n) {

--- a/src/test/java/com/thealgorithms/maths/GenericRootTest.java
+++ b/src/test/java/com/thealgorithms/maths/GenericRootTest.java
@@ -7,11 +7,18 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class GenericRootTest {
+    private final Map<Integer, Integer> testCases = Map.ofEntries(entry(0, 0), entry(1, 1), entry(12345, 6), entry(123, 6), entry(15937, 7), entry(222222, 3), entry(99999, 9));
     @Test
     public void testGenericRoot() {
-        final Map<Integer, Integer> testCases = Map.ofEntries(entry(0, 0), entry(1, 1), entry(12345, 6), entry(123, 6), entry(15937, 7), entry(222222, 3), entry(99999, 9));
         for (final var tc : testCases.entrySet()) {
             assertEquals(tc.getValue(), GenericRoot.genericRoot(tc.getKey()));
+        }
+    }
+
+    @Test
+    public void testGenericRootWithNegativeInputs() {
+        for (final var tc : testCases.entrySet()) {
+            assertEquals(tc.getValue(), GenericRoot.genericRoot(-tc.getKey()));
         }
     }
 }

--- a/src/test/java/com/thealgorithms/maths/GenericRootTest.java
+++ b/src/test/java/com/thealgorithms/maths/GenericRootTest.java
@@ -1,0 +1,17 @@
+package com.thealgorithms.maths;
+
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class GenericRootTest {
+    @Test
+    public void testGenericRoot() {
+        final Map<Integer, Integer> testCases = Map.ofEntries(entry(0, 0), entry(1, 1), entry(12345, 6), entry(123, 6), entry(15937, 7), entry(222222, 3), entry(99999, 9));
+        for (final var tc : testCases.entrySet()) {
+            assertEquals(tc.getValue(), GenericRoot.genericRoot(tc.getKey()));
+        }
+    }
+}


### PR DESCRIPTION
This PR:
- adds tests for the class [`GenericRoot`](https://github.com/TheAlgorithms/Java/blob/087d523ed0e747adb9a681499f40d427c84358d2/src/main/java/com/thealgorithms/maths/GenericRoot.java#L7),
- does some refactoring if it.

I do not know about the general policy here: should I use the existing methods from [`SumOfDigits`](https://github.com/TheAlgorithms/Java/blob/087d523ed0e747adb9a681499f40d427c84358d2/src/main/java/com/thealgorithms/maths/SumOfDigits.java#L3)?

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
