### PR TITLE
style: cleanup `PalindromeSinglyLinkedList`

### DIFF
--- a/src/main/java/com/thealgorithms/misc/PalindromeSinglyLinkedList.java
+++ b/src/main/java/com/thealgorithms/misc/PalindromeSinglyLinkedList.java
@@ -11,39 +11,23 @@ import java.util.Stack;
  * See more:
  * https://www.geeksforgeeks.org/function-to-check-if-a-singly-linked-list-is-palindrome/
  */
-public class PalindromeSinglyLinkedList {
-
-    public static void main(String[] args) {
-        SinglyLinkedList linkedList = new SinglyLinkedList();
-
-        linkedList.insertHead(3);
-        linkedList.insertNth(2, 1);
-        linkedList.insertNth(1, 2);
-        linkedList.insertNth(2, 3);
-        linkedList.insertNth(3, 4);
-
-        if (isPalindrome(linkedList)) {
-            System.out.println("It's a palindrome list");
-        } else {
-            System.out.println("It's NOT a palindrome list");
-        }
+public final class PalindromeSinglyLinkedList {
+    private PalindromeSinglyLinkedList() {
     }
 
-    public static boolean isPalindrome(SinglyLinkedList linkedList) {
-        boolean ret = true;
+    public static boolean isPalindrome(final SinglyLinkedList linkedList) {
         Stack<Integer> linkedListValues = new Stack<>();
 
-        for (int i = 0; i < linkedList.size(); i++) {
-            linkedListValues.push(linkedList.getNth(i));
+        for (final var x : linkedList) {
+            linkedListValues.push(x);
         }
 
-        for (int i = 0; i < linkedList.size(); i++) {
-            if (linkedList.getNth(i) != linkedListValues.pop()) {
-                ret = false;
-                break;
+        for (final var x : linkedList) {
+            if (x != linkedListValues.pop()) {
+                return false;
             }
         }
 
-        return ret;
+        return true;
     }
 }

--- a/src/test/java/com/thealgorithms/misc/PalindromeSinglyLinkedListTest.java
+++ b/src/test/java/com/thealgorithms/misc/PalindromeSinglyLinkedListTest.java
@@ -29,6 +29,17 @@ public class PalindromeSinglyLinkedListTest {
     }
 
     @Test
+    public void testWithListWithOddLengthPositive2() {
+        var exampleList = new SinglyLinkedList();
+        exampleList.insert(3);
+        exampleList.insert(2);
+        exampleList.insert(1);
+        exampleList.insert(2);
+        exampleList.insert(3);
+        assertTrue(PalindromeSinglyLinkedList.isPalindrome(exampleList));
+    }
+
+    @Test
     public void testWithListWithEvenLengthPositive() {
         var exampleList = new SinglyLinkedList();
         exampleList.insert(10);


### PR DESCRIPTION
As mentioned in #4327, the implementation of [`PalindromeSinglyLinkedList.isPalindrome`](https://github.com/TheAlgorithms/Java/blob/ea15f2bd98c24150b590fac800e386d2f98b203d/src/main/java/com/thealgorithms/misc/PalindromeSinglyLinkedList.java#L32) has unnecessarily high time complexity `O(n^2)`. Thanks to #4334, the implementation could be changed to optimal `O(n)`. This PR does that and makes `PalindromeSinglyLinkedList` a proper utility class.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
