### PR TITLE
chore: configure `clang-format-16` in gitpod

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,11 +1,22 @@
 FROM gitpod/workspace-java-17:2023-08-30-14-07-38
 
+ENV LLVM_SCRIPT="tmp_llvm.sh"
+
+RUN test ! -f  "$LLVM_SCRIPT" \
+  && wget https://apt.llvm.org/llvm.sh -O "$LLVM_SCRIPT" \
+  && chmod +x "$LLVM_SCRIPT"
+
 USER root
 
-RUN apt-get update \
+RUN ./"$LLVM_SCRIPT" 16 \
+  && apt-get update \
   && apt-get install -y --no-install-recommends \
-  clang-format=1:14.0-55~exp2 \
+  clang-format-16=1:16.0.6~++20230710042027+7cbf1a259152-1~exp1~20230710162048.105 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+RUN ln -s "$(command -v clang-format-16)" "/usr/bin/clang-format"
+
 USER gitpod
+
+RUN rm "$LLVM_SCRIPT"


### PR DESCRIPTION
This PR configures `clang-format-16` in gitpod (cf. #4343).

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
