### PR TITLE
chore: update `actions/checkout` to `v4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/clang-format-lint.yml
+++ b/.github/workflows/clang-format-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         source: './src'


### PR DESCRIPTION
The `actions/checkout@v4` was recently [released](https://github.com/actions/checkout/releases/tag/v4.0.0). This PR makes a suitable update.

Please note the following inconsistency:
https://github.com/TheAlgorithms/Java/blob/09950d6097ea7b2590fb80336d144ee402e61226/.github/workflows/update_directory.yml#L27


<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] ~All filenames are in PascalCase.~
- [x] ~All functions and variable names follow Java naming conventions.~
- [x] ~All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.~
