### PR TITLE
#4358 Fix : Floodfill infinite recursion due to same color

### DIFF
--- a/src/main/java/com/thealgorithms/backtracking/FloodFill.java
+++ b/src/main/java/com/thealgorithms/backtracking/FloodFill.java
@@ -39,6 +39,7 @@ public class FloodFill {
      * @param oldColor The old color which is to be replaced in the image
      */
     public static void floodFill(int[][] image, int x, int y, int newColor, int oldColor) {
+        if (newColor == oldColor) return;
         if (x < 0 || x >= image.length) return;
         if (y < 0 || y >= image[x].length) return;
         if (getPixel(image, x, y) != oldColor) return;

--- a/src/test/java/com/thealgorithms/backtracking/FloodFillTest.java
+++ b/src/test/java/com/thealgorithms/backtracking/FloodFillTest.java
@@ -93,4 +93,14 @@ class FloodFillTest {
         FloodFill.floodFill(image, 0, 1, 4, 1);
         assertArrayEquals(expected, image);
     }
+
+    @Test
+    void testForSameNewAndOldColor() {
+        int[][] image = {{1, 1, 2}, {1, 0, 0}, {1, 1, 1}};
+
+        int[][] expected = {{1, 1, 2}, {1, 0, 0}, {1, 1, 1}};
+
+        FloodFill.floodFill(image, 0, 1, 1, 1);
+        assertArrayEquals(expected, image);
+    }
 }


### PR DESCRIPTION
<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.

Fixed #4358 
Fixed case when both newColor and oldColor is passed as same integer causing infinite recursion by adding extra base condition.
Also added testcase for same and after that ran all testcase, which resulted as all passed.

<img width="1511" alt="Screenshot 2023-09-09 at 6 04 36 PM" src="https://github.com/TheAlgorithms/Java/assets/76104205/b046b071-d9c3-443b-83c4-16075332724c">

