### PR TITLE
refactor: simplify `ParseInteger`

### DIFF
--- a/src/main/java/com/thealgorithms/maths/ParseInteger.java
+++ b/src/main/java/com/thealgorithms/maths/ParseInteger.java
@@ -1,6 +1,28 @@
 package com.thealgorithms.maths;
 
-public class ParseInteger {
+public final class ParseInteger {
+    private ParseInteger() {
+    }
+
+    private static void checkInput(final String s) {
+        if (s == null) {
+            throw new NumberFormatException("Input parameter must not be null!");
+        }
+        if (s.isEmpty()) {
+            throw new NumberFormatException("Input parameter must not be empty!");
+        }
+    }
+
+    private static void checkDigitAt(final String s, final int pos) {
+        if (!Character.isDigit(s.charAt(pos))) {
+            throw new NumberFormatException("Input parameter of incorrect format: " + s);
+        }
+    }
+
+    private static int digitToInt(final char digit) {
+        return digit - '0';
+    }
+
     /**
      * Parse a string to integer
      *
@@ -9,18 +31,15 @@ public class ParseInteger {
      * @throws NumberFormatException if the {@code string} does not contain a
      *                               parsable integer.
      */
-    public static int parseInt(String s) {
-        if (s == null || s.length() == 0) {
-            throw new NumberFormatException("Input parameter must not be null!");
-        }
-        boolean isNegative = s.charAt(0) == '-';
-        boolean isPositive = s.charAt(0) == '+';
+    public static int parseInt(final String s) {
+        checkInput(s);
+
+        final boolean isNegative = s.charAt(0) == '-';
+        final boolean isPositive = s.charAt(0) == '+';
         int number = 0;
-        for (int i = isNegative ? 1 : isPositive ? 1 : 0, length = s.length(); i < length; ++i) {
-            if (!Character.isDigit(s.charAt(i))) {
-                throw new NumberFormatException("Input parameter of incorrect format: " + s);
-            }
-            number = number * 10 + s.charAt(i) - '0';
+        for (int i = isNegative || isPositive ? 1 : 0, length = s.length(); i < length; ++i) {
+            checkDigitAt(s, i);
+            number = number * 10 + digitToInt(s.charAt(i));
         }
         return isNegative ? -number : number;
     }

--- a/src/test/java/com/thealgorithms/maths/ParseIntegerTest.java
+++ b/src/test/java/com/thealgorithms/maths/ParseIntegerTest.java
@@ -8,12 +8,19 @@ import org.junit.jupiter.api.Test;
  */
 public class ParseIntegerTest {
     private static final String NULL_PARAMETER_MESSAGE = "Input parameter must not be null!";
+    private static final String EMPTY_PARAMETER_MESSAGE = "Input parameter must not be empty!";
     private static final String INCORRECT_FORMAT_MESSAGE = "Input parameter of incorrect format";
 
     @Test
     public void testNullInput() {
         IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> ParseInteger.parseInt(null));
         Assertions.assertEquals(exception.getMessage(), NULL_PARAMETER_MESSAGE);
+    }
+
+    @Test
+    public void testEmptyInput() {
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> ParseInteger.parseInt(""));
+        Assertions.assertEquals(exception.getMessage(), EMPTY_PARAMETER_MESSAGE);
     }
 
     @Test


### PR DESCRIPTION
<!-- For completed items, change [ ] to [x] -->
This PR simplifies method [`ParseInteger.parseInt`](https://github.com/TheAlgorithms/Java/blob/5bb54977fe63107c22116215023cb18fc5500113/src/main/java/com/thealgorithms/maths/ParseInteger.java#L12). It also does some _basic linting_ and adds a missing test case.


- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
