### PR TITLE
remove array len + Math.max

### DIFF
--- a/src/main/java/com/thealgorithms/maths/FindMaxRecursion.java
+++ b/src/main/java/com/thealgorithms/maths/FindMaxRecursion.java
@@ -17,7 +17,7 @@ public class FindMaxRecursion {
             array[i] = rand.nextInt() % 100;
         }
 
-        assert max(array, array.length) == Arrays.stream(array).max().getAsInt();
+        assert max(array) == Arrays.stream(array).max().getAsInt();
         assert max(array, 0, array.length - 1) == Arrays.stream(array).max().getAsInt();
     }
 

--- a/src/main/java/com/thealgorithms/maths/FindMaxRecursion.java
+++ b/src/main/java/com/thealgorithms/maths/FindMaxRecursion.java
@@ -39,17 +39,16 @@ public class FindMaxRecursion {
         int leftMax = max(array, low, mid); // get max in [low, mid]
         int rightMax = max(array, mid + 1, high); // get max in [mid+1, high]
 
-        return Math.max(leftMax, rightMax);
+        return leftMax < rightMax ? rightMax : leftMax;
     }
 
     /**
      * Get max of array using recursion algorithm
      *
      * @param array contains elements
-     * @param len length of given array
      * @return max value of {@code array}
      */
-    public static int max(int[] array, int len) {
-        return len == 1 ? array[0] : Math.max(max(array, len - 1), array[len - 1]);
+    public static int max(int[] array) {
+        return array.length == 1 ? array[0] : max(array, 0, array.length);
     }
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.

Adding so the base function does not need a second parameter len and removing Math.max function as it ruins the purpose of the algorithem