### PR TITLE
tests: add test case with minimum not at index 0

### DIFF
--- a/src/test/java/com/thealgorithms/maths/FindMinTest.java
+++ b/src/test/java/com/thealgorithms/maths/FindMinTest.java
@@ -18,7 +18,7 @@ public class FindMinTest {
     }
 
     private static Stream<Arguments> provideStringsForIsBlank() {
-        return Stream.of(Arguments.of(1, new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), Arguments.of(5, new int[] {5, 5, 5, 5, 5}), Arguments.of(0, new int[] {0, 192, 384, 576}), Arguments.of(-1, new int[] {-1, 2, 5, 10}), Arguments.of(-10, new int[] {-10, -9, -8, -7, -6, -5, -4, -3, -2, -1}));
+        return Stream.of(Arguments.of(1, new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), Arguments.of(5, new int[] {5, 5, 5, 5, 5}), Arguments.of(0, new int[] {0, 192, 384, 576}), Arguments.of(-1, new int[] {-1, 2, 5, 10}), Arguments.of(-10, new int[] {-10, -9, -8, -7, -6, -5, -4, -3, -2, -1}), Arguments.of(-4, new int[] {4, -3, 8, 9, -4, -4, 10}));
     }
 
     @Test

--- a/src/test/java/com/thealgorithms/maths/FindMinTest.java
+++ b/src/test/java/com/thealgorithms/maths/FindMinTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class FindMinTest {
 
     @ParameterizedTest
-    @MethodSource("provideStringsForIsBlank")
+    @MethodSource("inputStream")
     void numberTests(int expected, int[] input) {
         Assertions.assertEquals(expected, FindMin.findMin(input));
     }
 
-    private static Stream<Arguments> provideStringsForIsBlank() {
+    private static Stream<Arguments> inputStream() {
         return Stream.of(Arguments.of(1, new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), Arguments.of(5, new int[] {5, 5, 5, 5, 5}), Arguments.of(0, new int[] {0, 192, 384, 576}), Arguments.of(-1, new int[] {-1, 2, 5, 10}), Arguments.of(-10, new int[] {-10, -9, -8, -7, -6, -5, -4, -3, -2, -1}),
             Arguments.of(-4, new int[] {4, -3, 8, 9, -4, -4, 10}));
     }

--- a/src/test/java/com/thealgorithms/maths/FindMinTest.java
+++ b/src/test/java/com/thealgorithms/maths/FindMinTest.java
@@ -18,7 +18,8 @@ public class FindMinTest {
     }
 
     private static Stream<Arguments> provideStringsForIsBlank() {
-        return Stream.of(Arguments.of(1, new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), Arguments.of(5, new int[] {5, 5, 5, 5, 5}), Arguments.of(0, new int[] {0, 192, 384, 576}), Arguments.of(-1, new int[] {-1, 2, 5, 10}), Arguments.of(-10, new int[] {-10, -9, -8, -7, -6, -5, -4, -3, -2, -1}), Arguments.of(-4, new int[] {4, -3, 8, 9, -4, -4, 10}));
+        return Stream.of(Arguments.of(1, new int[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}), Arguments.of(5, new int[] {5, 5, 5, 5, 5}), Arguments.of(0, new int[] {0, 192, 384, 576}), Arguments.of(-1, new int[] {-1, 2, 5, 10}), Arguments.of(-10, new int[] {-10, -9, -8, -7, -6, -5, -4, -3, -2, -1}),
+            Arguments.of(-4, new int[] {4, -3, 8, 9, -4, -4, 10}));
     }
 
     @Test


### PR DESCRIPTION
#4388 has updated testcases in `FindMinTest`, but for all test arrays the minimal value is at index 0. This PR fixes that.

@siriak, @lukasb1b please have a look.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
