### PR TITLE
Use explicit cast to `int` in `FractionalKnapsack`

### DIFF
--- a/src/main/java/com/thealgorithms/greedyalgorithms/FractionalKnapsack.java
+++ b/src/main/java/com/thealgorithms/greedyalgorithms/FractionalKnapsack.java
@@ -32,7 +32,7 @@ public class FractionalKnapsack {
                 current -= weight[index];
             } else {
                 // If only a fraction of the item can fit, add a proportionate value.
-                finalValue += ratio[i][1] * current;
+                finalValue += (int) (ratio[i][1] * current);
                 break; // Stop adding items to the knapsack since it's full.
             }
         }


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`

Fixes one of the issues detected by merging #4966. Similar to #4970.