### PR TITLE
Fixed wrong compare() method for subset check (S.A ⊆ T.A)

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -528,7 +528,7 @@
             * [InfixToPostfix](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/InfixToPostfix.java)
             * [LargestRectangle](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/LargestRectangle.java)
             * [MaximumMinimumWindow](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/MaximumMinimumWindow.java)
-            * [NextGraterElement](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/NextGraterElement.java)
+            * [NextGreaterElement](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/NextGreaterElement.java)
             * [NextSmallerElement](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/NextSmallerElement.java)
             * [PostfixToInfix](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/PostfixToInfix.java)
             * [StackPostfixNotation](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/StackPostfixNotation.java)

--- a/src/main/java/com/thealgorithms/datastructures/crdt/GSet.java
+++ b/src/main/java/com/thealgorithms/datastructures/crdt/GSet.java
@@ -50,7 +50,7 @@ public class GSet<T> {
      * @return true if the current G-Set is a subset of the other, false otherwise
      */
     public boolean compare(GSet<T> other) {
-        return elements.containsAll(other.elements);
+        return other.elements.containsAll(elements);
     }
 
     /**

--- a/src/test/java/com/thealgorithms/datastructures/crdt/GSetTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/crdt/GSetTest.java
@@ -32,20 +32,14 @@ class GSetTest {
     void testCompare() {
         GSet<String> gSet1 = new GSet<>();
         GSet<String> gSet2 = new GSet<>();
-
         gSet1.addElement("apple");
         gSet1.addElement("orange");
-
         gSet2.addElement("orange");
-        gSet2.addElement("banana");
-
         assertFalse(gSet1.compare(gSet2));
-
-        GSet<String> gSet3 = new GSet<>();
-        gSet3.addElement("apple");
-        gSet3.addElement("orange");
-
-        assertTrue(gSet1.compare(gSet3));
+        gSet2.addElement("apple");
+        assertTrue(gSet1.compare(gSet2));
+        gSet2.addElement("banana");
+        assertTrue(gSet1.compare(gSet2));
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

Fixed bug in the `compare()` method where the subet check is not performed on the actual object.

from:
```java
    public boolean compare(GSet<T> other) {
        return elements.containsAll(other.elements);
    }
```
to:
```java
    public boolean compare(GSet<T> other) {
        return other.elements.containsAll(elements);
    }
```

See:
compare (S, T) : boolean b
    let b = (S.A ⊆ T.A)
    
https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type

- [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [X] This pull request is all my own work -- I have not plagiarized it.
- [X] All filenames are in PascalCase.
- [X] All functions and variable names follow Java naming conventions.
- [X] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [X] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`