### PR TITLE
Updated TwoPSet to use Generics instead of Strings

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -528,7 +528,7 @@
             * [InfixToPostfix](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/InfixToPostfix.java)
             * [LargestRectangle](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/LargestRectangle.java)
             * [MaximumMinimumWindow](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/MaximumMinimumWindow.java)
-            * [NextGraterElement](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/NextGraterElement.java)
+            * [NextGreaterElement](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/NextGreaterElement.java)
             * [NextSmallerElement](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/NextSmallerElement.java)
             * [PostfixToInfix](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/PostfixToInfix.java)
             * [StackPostfixNotation](https://github.com/TheAlgorithms/Java/blob/master/src/main/java/com/thealgorithms/stacks/StackPostfixNotation.java)

--- a/src/main/java/com/thealgorithms/datastructures/crdt/TwoPSet.java
+++ b/src/main/java/com/thealgorithms/datastructures/crdt/TwoPSet.java
@@ -15,9 +15,9 @@ import java.util.Set;
  * @author itakurah (Niklas Hoefflin) (https://github.com/itakurah)
  */
 
-public class TwoPSet {
-    private Set<String> setA;
-    private Set<String> setR;
+public class TwoPSet<T> {
+    private final Set<T> setA;
+    private final Set<T> setR;
 
     /**
      * Constructs an empty Two-Phase Set.
@@ -33,7 +33,7 @@ public class TwoPSet {
      * @param element The element to be checked.
      * @return True if the element is in the set and has not been removed, otherwise false.
      */
-    public boolean lookup(String element) {
+    public boolean lookup(T element) {
         return setA.contains(element) && !setR.contains(element);
     }
 
@@ -42,7 +42,7 @@ public class TwoPSet {
      *
      * @param element The element to be added.
      */
-    public void add(String element) {
+    public void add(T element) {
         setA.add(element);
     }
 
@@ -51,7 +51,7 @@ public class TwoPSet {
      *
      * @param element The element to be removed.
      */
-    public void remove(String element) {
+    public void remove(T element) {
         if (lookup(element)) {
             setR.add(element);
         }
@@ -63,7 +63,7 @@ public class TwoPSet {
      * @param otherSet The other 2P-Set to compare with.
      * @return True if both SetA and SetR are subset, otherwise false.
      */
-    public boolean compare(TwoPSet otherSet) {
+    public boolean compare(TwoPSet<T> otherSet) {
         return otherSet.setA.containsAll(setA) && otherSet.setR.containsAll(setR);
     }
 
@@ -73,8 +73,8 @@ public class TwoPSet {
      * @param otherSet The other 2P-Set to merge with.
      * @return A new 2P-Set containing the merged elements.
      */
-    public TwoPSet merge(TwoPSet otherSet) {
-        TwoPSet mergedSet = new TwoPSet();
+    public TwoPSet<T> merge(TwoPSet<T> otherSet) {
+        TwoPSet<T> mergedSet = new TwoPSet<>();
         mergedSet.setA.addAll(this.setA);
         mergedSet.setA.addAll(otherSet.setA);
         mergedSet.setR.addAll(this.setR);

--- a/src/test/java/com/thealgorithms/datastructures/crdt/TwoPSetTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/crdt/TwoPSetTest.java
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test;
 
 class TwoPSetTest {
 
-    private TwoPSet set;
+    private TwoPSet<String> set;
 
     @BeforeEach
     void setUp() {
-        set = new TwoPSet();
+        set = new TwoPSet<>();
     }
 
     @Test
@@ -38,10 +38,10 @@ class TwoPSetTest {
 
     @Test
     void testCompare() {
-        TwoPSet set1 = new TwoPSet();
+        TwoPSet<String> set1 = new TwoPSet<>();
         set1.add("A");
         set1.add("B");
-        TwoPSet set2 = new TwoPSet();
+        TwoPSet<String> set2 = new TwoPSet<>();
         set2.add("A");
         assertFalse(set1.compare(set2));
         set2.add("B");
@@ -54,13 +54,13 @@ class TwoPSetTest {
 
     @Test
     void testMerge() {
-        TwoPSet set1 = new TwoPSet();
+        TwoPSet<String> set1 = new TwoPSet<>();
         set1.add("A");
         set1.add("B");
-        TwoPSet set2 = new TwoPSet();
+        TwoPSet<String> set2 = new TwoPSet<>();
         set2.add("B");
         set2.add("C");
-        TwoPSet mergedSet = set1.merge(set2);
+        TwoPSet<String> mergedSet = set1.merge(set2);
         assertTrue(mergedSet.lookup("A"));
         assertTrue(mergedSet.lookup("B"));
         assertTrue(mergedSet.lookup("C"));


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

This PR updates the `TwoPSet.java` and `TwoPSetTest.java` to use Generics `TwoPSet<T>` instead of `TwoPSet<String>` to make the class more flexible and to allow the use of custom objects with `TwoPSet`.

````java
public class TwoPSet<T> {
    private final Set<T> setA;
    private final Set<T> setR;
````

- [X] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [X] This pull request is all my own work -- I have not plagiarized it.
- [X] All filenames are in PascalCase.
- [X] All functions and variable names follow Java naming conventions.
- [X] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [X] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`