### PR TITLE
Cleanup `SumOfDigits` and its tests

### DIFF
--- a/src/main/java/com/thealgorithms/maths/SumOfDigits.java
+++ b/src/main/java/com/thealgorithms/maths/SumOfDigits.java
@@ -1,13 +1,7 @@
 package com.thealgorithms.maths;
 
-public class SumOfDigits {
-
-    public static void main(String[] args) {
-        assert sumOfDigits(-123) == 6 && sumOfDigitsRecursion(-123) == 6 && sumOfDigitsFast(-123) == 6;
-
-        assert sumOfDigits(0) == 0 && sumOfDigitsRecursion(0) == 0 && sumOfDigitsFast(0) == 0;
-
-        assert sumOfDigits(12345) == 15 && sumOfDigitsRecursion(12345) == 15 && sumOfDigitsFast(12345) == 15;
+public final class SumOfDigits {
+    private SumOfDigits() {
     }
 
     /**
@@ -17,12 +11,12 @@ public class SumOfDigits {
      * @return sum of digits of given {@code number}
      */
     public static int sumOfDigits(int number) {
-        number = number < 0 ? -number : number;
-        /* calculate abs value */
+        final int base = 10;
+        number = Math.abs(number);
         int sum = 0;
         while (number != 0) {
-            sum += number % 10;
-            number /= 10;
+            sum += number % base;
+            number /= base;
         }
         return sum;
     }
@@ -34,9 +28,9 @@ public class SumOfDigits {
      * @return sum of digits of given {@code number}
      */
     public static int sumOfDigitsRecursion(int number) {
-        number = number < 0 ? -number : number;
-        /* calculate abs value */
-        return number < 10 ? number : number % 10 + sumOfDigitsRecursion(number / 10);
+        final int base = 10;
+        number = Math.abs(number);
+        return number < base ? number : number % base + sumOfDigitsRecursion(number / base);
     }
 
     /**
@@ -45,14 +39,7 @@ public class SumOfDigits {
      * @param number the number contains digits
      * @return sum of digits of given {@code number}
      */
-    public static int sumOfDigitsFast(int number) {
-        number = number < 0 ? -number : number;
-        /* calculate abs value */
-        char[] digits = (number + "").toCharArray();
-        int sum = 0;
-        for (int i = 0; i < digits.length; ++i) {
-            sum += digits[i] - '0';
-        }
-        return sum;
+    public static int sumOfDigitsFast(final int number) {
+        return String.valueOf(Math.abs(number)).chars().map(c -> c - '0').reduce(0, Integer::sum);
     }
 }

--- a/src/test/java/com/thealgorithms/maths/SumOfDigitsTest.java
+++ b/src/test/java/com/thealgorithms/maths/SumOfDigitsTest.java
@@ -1,31 +1,31 @@
 package com.thealgorithms.maths;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SumOfDigitsTest {
-
-    SumOfDigits SoD = new SumOfDigits();
-
-    @Test
-    void testZero() {
-        assertEquals(0, SumOfDigits.sumOfDigits(0));
-        assertEquals(0, SumOfDigits.sumOfDigitsRecursion(0));
-        assertEquals(0, SumOfDigits.sumOfDigitsFast(0));
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void sumOfDigitsTest(final int expected, final int input) {
+        Assertions.assertEquals(expected, SumOfDigits.sumOfDigits(input));
     }
 
-    @Test
-    void testPositive() {
-        assertEquals(15, SumOfDigits.sumOfDigits(12345));
-        assertEquals(15, SumOfDigits.sumOfDigitsRecursion(12345));
-        assertEquals(15, SumOfDigits.sumOfDigitsFast(12345));
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void sumOfDigitsRecursionTest(final int expected, final int input) {
+        Assertions.assertEquals(expected, SumOfDigits.sumOfDigitsRecursion(input));
     }
 
-    @Test
-    void testNegative() {
-        assertEquals(6, SumOfDigits.sumOfDigits(-123));
-        assertEquals(6, SumOfDigits.sumOfDigitsRecursion(-123));
-        assertEquals(6, SumOfDigits.sumOfDigitsFast(-123));
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void sumOfDigitsFastTest(final int expected, final int input) {
+        Assertions.assertEquals(expected, SumOfDigits.sumOfDigitsFast(input));
+    }
+
+    private static Stream<Arguments> testCases() {
+        return Stream.of(Arguments.of(0, 0), Arguments.of(1, 1), Arguments.of(15, 12345), Arguments.of(6, -123), Arguments.of(1, -100000), Arguments.of(8, 512));
     }
 }


### PR DESCRIPTION
This PR is a pretty straightforward cleanup of the `SumOfDigits`, namely it:
- uses `Math.abs`,
- makes `sumOfDigitsFast` more _functional_,
- rewrites tests as _parameterized test_.
<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`