### PR TITLE
Remove unused imports from `BoyerMooreTest`

### DIFF
--- a/src/test/java/com/thealgorithms/others/BoyerMooreTest.java
+++ b/src/test/java/com/thealgorithms/others/BoyerMooreTest.java
@@ -1,9 +1,7 @@
 package com.thealgorithms.others;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;


### PR DESCRIPTION
This PR removed unused import from `BoyerMooreTest`. Similar to #5010.

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
