### PR TITLE
fix: update `clang-format` tag

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -11,7 +11,7 @@ USER root
 RUN ./"$LLVM_SCRIPT" 16 \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  clang-format-16=1:16.0.6~++20230710042027+7cbf1a259152-1~exp1~20230710162048.105 \
+  clang-format-16=1:16.0.6~++20231112100510+7cbf1a259152-1~exp1~20231112100554.106 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -578,6 +578,7 @@
             * [FloodFillTest](https://github.com/TheAlgorithms/Java/blob/master/src/test/java/com/thealgorithms/backtracking/FloodFillTest.java)
             * [MazeRecursionTest](https://github.com/TheAlgorithms/Java/blob/master/src/test/java/com/thealgorithms/backtracking/MazeRecursionTest.java)
             * [MColoringTest](https://github.com/TheAlgorithms/Java/blob/master/src/test/java/com/thealgorithms/backtracking/MColoringTest.java)
+            * [ParenthesesGeneratorTest](https://github.com/TheAlgorithms/Java/blob/master/src/test/java/com/thealgorithms/backtracking/ParenthesesGeneratorTest.java)
             * [PermutationTest](https://github.com/TheAlgorithms/Java/blob/master/src/test/java/com/thealgorithms/backtracking/PermutationTest.java)
             * [PowerSumTest](https://github.com/TheAlgorithms/Java/blob/master/src/test/java/com/thealgorithms/backtracking/PowerSumTest.java)
             * [WordSearchTest](https://github.com/TheAlgorithms/Java/blob/master/src/test/java/com/thealgorithms/backtracking/WordSearchTest.java)


### PR DESCRIPTION
After #5092 build of the gitpod image fails at installing `clang-format`. This PR fixes that by updating the `clang-format` tag. @BamaCharanChhandogi please have a look.