### PR TITLE
fix: constant inputs in `LongestIncreasingSubsequence::findLISLen`

### DIFF
--- a/src/main/java/com/thealgorithms/dynamicprogramming/LongestIncreasingSubsequence.java
+++ b/src/main/java/com/thealgorithms/dynamicprogramming/LongestIncreasingSubsequence.java
@@ -1,26 +1,10 @@
 package com.thealgorithms.dynamicprogramming;
 
-import java.util.Scanner;
-
 /**
  * @author Afrizal Fikri (https://github.com/icalF)
  */
 public final class LongestIncreasingSubsequence {
     private LongestIncreasingSubsequence() {
-    }
-
-    public static void main(String[] args) {
-        Scanner sc = new Scanner(System.in);
-        int n = sc.nextInt();
-
-        int[] arr = new int[n];
-        for (int i = 0; i < n; i++) {
-            arr[i] = sc.nextInt();
-        }
-
-        System.out.println(LIS(arr));
-        System.out.println(findLISLen(arr));
-        sc.close();
     }
 
     private static int upperBound(int[] ar, int l, int r, int key) {
@@ -36,7 +20,7 @@ public final class LongestIncreasingSubsequence {
         return r;
     }
 
-    private static int LIS(int[] array) {
+    public static int LIS(int[] array) {
         int N = array.length;
         if (N == 0) {
             return 0;
@@ -73,14 +57,17 @@ public final class LongestIncreasingSubsequence {
      */
     // A function for finding the length of the LIS algorithm in O(nlogn) complexity.
     public static int findLISLen(int[] a) {
-        int size = a.length;
+        final int size = a.length;
+        if (size == 0) {
+            return 0;
+        }
         int[] arr = new int[size];
         arr[0] = a[0];
         int lis = 1;
         for (int i = 1; i < size; i++) {
-            int index = binarySearchBetween(arr, lis, a[i]);
+            int index = binarySearchBetween(arr, lis - 1, a[i]);
             arr[index] = a[i];
-            if (index > lis) {
+            if (index == lis) {
                 lis++;
             }
         }

--- a/src/test/java/com/thealgorithms/dynamicprogramming/LongestIncreasingSubsequenceTests.java
+++ b/src/test/java/com/thealgorithms/dynamicprogramming/LongestIncreasingSubsequenceTests.java
@@ -1,0 +1,49 @@
+package com.thealgorithms.dynamicprogramming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class LongestIncreasingSubsequenceTests {
+    @FunctionalInterface
+    public interface IntArrayToInt {
+        int apply(int[] array);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    public void testLongestIncreasingSubsequence(final int expected, final int[] input, final IntArrayToInt method) {
+        assertEquals(expected, method.apply(input));
+    }
+
+    private static Stream<Arguments> testCases() {
+        final Object[][] testData = {
+            {0, new int[] {}},
+            {1, new int[] {1}},
+            {1, new int[] {2, 2}},
+            {1, new int[] {3, 3, 3}},
+            {1, new int[] {4, 4, 4, 4}},
+            {1, new int[] {5, 5, 5, 5, 5}},
+            {2, new int[] {1, 2}},
+            {2, new int[] {1, 2, 2, 2, 2}},
+            {2, new int[] {1, 0, 2}},
+            {3, new int[] {1, 10, 2, 30}},
+            {3, new int[] {5, 8, 3, 7, 9, 1}},
+            {6, new int[] {0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15}},
+            {4, new int[] {10, 9, 2, 5, 3, 7, 101, 18}},
+            {4, new int[] {10, 10, 9, 9, 2, 2, 5, 5, 3, 3, 7, 7, 101, 101, 18, 18}},
+            {4, new int[] {0, 1, 0, 3, 2, 3}},
+            {2, new int[] {1, 1, 2, 2, 2}},
+            {3, new int[] {1, 1, 2, 2, 2, 3, 3, 3, 3}},
+        };
+
+        final List<IntArrayToInt> methods = Arrays.asList(LongestIncreasingSubsequence::LIS, LongestIncreasingSubsequence::findLISLen);
+
+        return Stream.of(testData).flatMap(input -> methods.stream().map(method -> Arguments.of(input[0], input[1], method)));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->
This PR adds missing tests, fixes `LongestIncreasingSubsequence::findLISLen` to handle constant and empty inputs and removes the `main` method from `LongestIncreasingSubsequence`.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`