### PR TITLE
style: enable compiler warnings and treat them as errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,15 @@
                 <configuration>
                     <source>17</source>
                     <target>17</target>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                        <arg>-Xlint:-auxiliaryclass</arg>
+                        <arg>-Xlint:-rawtypes</arg>
+                        <arg>-Xlint:-serial</arg>
+                        <arg>-Xlint:-try</arg>
+                        <arg>-Xlint:-unchecked</arg>
+                        <arg>-Werror</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

This PR enables the compiler warnings and treats them as errors. The goal is to remove all of the lines _suppressing_ some of the warnings, i.e.
```xml
<arg>-Xlint:-auxiliaryclass</arg>
<arg>-Xlint:-rawtypes</arg>
<arg>-Xlint:-serial</arg>
<arg>-Xlint:-try</arg>
<arg>-Xlint:-unchecked</arg>
```

In case of Java 21 (#5163) two additional warnings needs to be suppressed (Java 17 does not know them):
```xml
<arg>-Xlint:-lossy-conversions</arg>
<arg>-Xlint:-this-escape</arg>
```

Similar to:
- #5110
- #5122
- #5155

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`