### PR TITLE
Replace the various swap method variants with SortUtils.swap

### DIFF
--- a/src/main/java/com/thealgorithms/sorts/DualPivotQuickSort.java
+++ b/src/main/java/com/thealgorithms/sorts/DualPivotQuickSort.java
@@ -45,7 +45,7 @@ public class DualPivotQuickSort implements SortAlgorithm {
      */
     private static <T extends Comparable<T>> int[] partition(T[] array, int left, int right) {
         if (array[left].compareTo(array[right]) > 0) {
-            swap(array, left, right);
+            SortUtils.swap(array, left, right);
         }
 
         T pivot1 = array[left];
@@ -58,7 +58,7 @@ public class DualPivotQuickSort implements SortAlgorithm {
         while (less <= great) {
             // If element is less than pivot1
             if (array[less].compareTo(pivot1) < 0) {
-                swap(array, less, left++);
+                SortUtils.swap(array, less, left++);
             }
 
             // If element is greater or equal to pivot2
@@ -67,10 +67,10 @@ public class DualPivotQuickSort implements SortAlgorithm {
                     great--;
                 }
 
-                swap(array, less, great--);
+                SortUtils.swap(array, less, great--);
 
                 if (array[less].compareTo(pivot1) < 0) {
-                    swap(array, less, left++);
+                    SortUtils.swap(array, less, left++);
                 }
             }
 
@@ -79,17 +79,11 @@ public class DualPivotQuickSort implements SortAlgorithm {
         j--;
         great++;
         // Bring the pivots to their appropriate positions
-        swap(array, left, j);
-        swap(array, right, great);
+        SortUtils.swap(array, left, j);
+        SortUtils.swap(array, right, great);
 
         // return the pivots' indices
         return new int[] {less, great};
-    }
-
-    private static <T extends Comparable<T>> void swap(T[] array, int left, int right) {
-        T temp = array[left];
-        array[left] = array[right];
-        array[right] = temp;
     }
 
     /**

--- a/src/main/java/com/thealgorithms/sorts/ExchangeSort.java
+++ b/src/main/java/com/thealgorithms/sorts/ExchangeSort.java
@@ -32,16 +32,10 @@ class ExchangeSort implements SortAlgorithm {
         for (int i = 0; i < array.length - 1; i++) {
             for (int j = i + 1; j < array.length; j++) {
                 if (array[i].compareTo(array[j]) > 0) {
-                    swap(array, i, j);
+                    SortUtils.swap(array, i, j);
                 }
             }
         }
         return array;
-    }
-
-    private <T> void swap(T[] array, int i, int j) {
-        T temp = array[i];
-        array[i] = array[j];
-        array[j] = temp;
     }
 }

--- a/src/main/java/com/thealgorithms/sorts/IntrospectiveSort.java
+++ b/src/main/java/com/thealgorithms/sorts/IntrospectiveSort.java
@@ -16,12 +16,6 @@ public class IntrospectiveSort implements SortAlgorithm {
         return a;
     }
 
-    private static <T extends Comparable<T>> void swap(T[] a, int i, int j) {
-        T temp = a[i];
-        a[i] = a[j];
-        a[j] = temp;
-    }
-
     private static <T extends Comparable<T>> void introSort(T[] a, int low, int high, int depth) {
         while (high - low > INSERTION_SORT_THRESHOLD) {
             if (depth == 0) {
@@ -37,16 +31,16 @@ public class IntrospectiveSort implements SortAlgorithm {
 
     private static <T extends Comparable<T>> int partition(T[] a, int low, int high) {
         int pivotIndex = low + (int) (Math.random() * (high - low + 1));
-        swap(a, pivotIndex, high);
+        SortUtils.swap(a, pivotIndex, high);
         T pivot = a[high];
         int i = low - 1;
         for (int j = low; j <= high - 1; j++) {
             if (a[j].compareTo(pivot) <= 0) {
                 i++;
-                swap(a, i, j);
+                SortUtils.swap(a, i, j);
             }
         }
-        swap(a, i + 1, high);
+        SortUtils.swap(a, i + 1, high);
         return i + 1;
     }
 
@@ -67,7 +61,7 @@ public class IntrospectiveSort implements SortAlgorithm {
             heapify(a, i, high - low + 1, low);
         }
         for (int i = high; i > low; i--) {
-            swap(a, low, i);
+            SortUtils.swap(a, low, i);
             heapify(a, low, i - low, low);
         }
     }
@@ -83,7 +77,7 @@ public class IntrospectiveSort implements SortAlgorithm {
             largest = right;
         }
         if (largest != i) {
-            swap(a, i, largest);
+            SortUtils.swap(a, i, largest);
             heapify(a, largest, n, low);
         }
     }

--- a/src/main/java/com/thealgorithms/sorts/SelectionSort.java
+++ b/src/main/java/com/thealgorithms/sorts/SelectionSort.java
@@ -1,7 +1,5 @@
 package com.thealgorithms.sorts;
 
-import static com.thealgorithms.sorts.SortUtils.swap;
-
 public class SelectionSort implements SortAlgorithm {
 
     /**
@@ -22,7 +20,7 @@ public class SelectionSort implements SortAlgorithm {
                 }
             }
             if (minIndex != i) {
-                swap(arr, i, minIndex);
+                SortUtils.swap(arr, i, minIndex);
             }
         }
         return arr;

--- a/src/main/java/com/thealgorithms/sorts/SimpleSort.java
+++ b/src/main/java/com/thealgorithms/sorts/SimpleSort.java
@@ -9,9 +9,7 @@ public class SimpleSort implements SortAlgorithm {
         for (int i = 0; i < length; i++) {
             for (int j = i + 1; j < length; j++) {
                 if (SortUtils.less(array[j], array[i])) {
-                    T element = array[j];
-                    array[j] = array[i];
-                    array[i] = element;
+                    SortUtils.swap(array, i, j);
                 }
             }
         }

--- a/src/main/java/com/thealgorithms/sorts/SlowSort.java
+++ b/src/main/java/com/thealgorithms/sorts/SlowSort.java
@@ -20,9 +20,7 @@ public class SlowSort implements SortAlgorithm {
         sort(array, i, m);
         sort(array, m + 1, j);
         if (SortUtils.less(array[j], array[m])) {
-            T temp = array[j];
-            array[j] = array[m];
-            array[m] = temp;
+            SortUtils.swap(array, j, m);
         }
         sort(array, i, j - 1);
     }

--- a/src/main/java/com/thealgorithms/sorts/SwapSort.java
+++ b/src/main/java/com/thealgorithms/sorts/SwapSort.java
@@ -18,9 +18,7 @@ public class SwapSort implements SortAlgorithm {
             int amountSmallerElements = this.getSmallerElementCount(array, index);
 
             if (amountSmallerElements > 0 && index != amountSmallerElements) {
-                T element = array[index];
-                array[index] = array[amountSmallerElements];
-                array[amountSmallerElements] = element;
+                SortUtils.swap(array, index, amountSmallerElements);
             } else {
                 index++;
             }


### PR DESCRIPTION
In the sorting algorithms, there are several different swap methods that duplicate each other. However, the method already exists in SortUtils.swap. These changes consolidate the various methods into a single, common one.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`