### PR TITLE
Refactor: Replace Swap and Comparison Methods with SortUtils Utility Methods

### DIFF
--- a/src/main/java/com/thealgorithms/sorts/HeapSort.java
+++ b/src/main/java/com/thealgorithms/sorts/HeapSort.java
@@ -14,33 +14,33 @@ public class HeapSort implements SortAlgorithm {
      * and provide adjusted values to the {@link SortUtils#swap(Object[], int, int)} methods.
      */
     @Override
-    public <T extends Comparable<T>> T[] sort(T[] unsorted) {
-        int n = unsorted.length;
-        heapify(unsorted, n);
+    public <T extends Comparable<T>> T[] sort(T[] array) {
+        int n = array.length;
+        heapify(array, n);
         while (n > 1) {
-            SortUtils.swap(unsorted, 0, n - 1);
+            SortUtils.swap(array, 0, n - 1);
             n--;
-            siftDown(unsorted, 1, n);
+            siftDown(array, 1, n);
         }
-        return unsorted;
+        return array;
     }
 
-    private static <T extends Comparable<T>> void heapify(T[] unsorted, int n) {
+    private static <T extends Comparable<T>> void heapify(T[] array, int n) {
         for (int k = n / 2; k >= 1; k--) {
-            siftDown(unsorted, k, n);
+            siftDown(array, k, n);
         }
     }
 
-    private static <T extends Comparable<T>> void siftDown(T[] unsorted, int k, int n) {
+    private static <T extends Comparable<T>> void siftDown(T[] array, int k, int n) {
         while (2 * k <= n) {
             int j = 2 * k;
-            if (j < n && SortUtils.less(unsorted[j - 1], unsorted[j])) {
+            if (j < n && SortUtils.less(array[j - 1], array[j])) {
                 j++;
             }
-            if (!SortUtils.less(unsorted[k - 1], unsorted[j - 1])) {
+            if (!SortUtils.less(array[k - 1], array[j - 1])) {
                 break;
             }
-            SortUtils.swap(unsorted, k - 1, j - 1);
+            SortUtils.swap(array, k - 1, j - 1);
             k = j;
         }
     }

--- a/src/main/java/com/thealgorithms/sorts/HeapSort.java
+++ b/src/main/java/com/thealgorithms/sorts/HeapSort.java
@@ -9,16 +9,17 @@ public class HeapSort implements SortAlgorithm {
 
     /**
      * For simplicity, we are considering the heap root index as 1 instead of 0.
-     * It simplifies future calculations. Because of that we are decreasing the
-     * provided indexes by 1 in {@link #swap(Object[], int, int)} and
-     * {@link #less(Comparable[], int, int)} functions.
+     * This approach simplifies future calculations. As a result, we decrease
+     * the indexes by 1 when calling {@link SortUtils#less(Comparable, Comparable)}
+     * and provide adjusted values to the {@link SortUtils#swap(Object[], int, int)} methods.
      */
     @Override
     public <T extends Comparable<T>> T[] sort(T[] unsorted) {
         int n = unsorted.length;
         heapify(unsorted, n);
         while (n > 1) {
-            swap(unsorted, 1, n--);
+            SortUtils.swap(unsorted, 0, n - 1);
+            n--;
             siftDown(unsorted, 1, n);
         }
         return unsorted;
@@ -33,24 +34,14 @@ public class HeapSort implements SortAlgorithm {
     private static <T extends Comparable<T>> void siftDown(T[] unsorted, int k, int n) {
         while (2 * k <= n) {
             int j = 2 * k;
-            if (j < n && less(unsorted, j, j + 1)) {
+            if (j < n && SortUtils.less(unsorted[j - 1], unsorted[j])) {
                 j++;
             }
-            if (!less(unsorted, k, j)) {
+            if (!SortUtils.less(unsorted[k - 1], unsorted[j - 1])) {
                 break;
             }
-            swap(unsorted, k, j);
+            SortUtils.swap(unsorted, k - 1, j - 1);
             k = j;
         }
-    }
-
-    private static <T> void swap(T[] array, int idx, int idy) {
-        T swap = array[idx - 1];
-        array[idx - 1] = array[idy - 1];
-        array[idy - 1] = swap;
-    }
-
-    private static <T extends Comparable<T>> boolean less(T[] array, int idx, int idy) {
-        return array[idx - 1].compareTo(array[idy - 1]) < 0;
     }
 }


### PR DESCRIPTION
The HeapSort class had duplicated methods for less and swap, which already exist in SortUtils. 

It is better to use the common methods instead of the old ones. 

This pull request also includes some renaming for clarity.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`