### PR TITLE
fix: avoid infinite loop in `SwapSort`

### DIFF
--- a/src/main/java/com/thealgorithms/sorts/SwapSort.java
+++ b/src/main/java/com/thealgorithms/sorts/SwapSort.java
@@ -9,25 +9,32 @@ package com.thealgorithms.sorts;
  */
 public class SwapSort implements SortAlgorithm {
 
-    /**
-     * Sorts the input array using the swap sort algorithm.
-     *
-     * @param array the array to be sorted
-     * @param <T>   the type of elements in the array, which must be Comparable
-     * @return the sorted array
-     */
     @Override
     public <T extends Comparable<T>> T[] sort(T[] array) {
         int len = array.length;
+        int index = 0;
 
-        for (int i = 0; i < len - 1; i++) {
-            for (int j = i + 1; j < len; j++) {
-                if (SortUtils.less(array[j], array[i])) {
-                    SortUtils.swap(array, i, j);
-                }
+        while (index < len - 1) {
+            int amountSmallerElements = this.getSmallerElementCount(array, index);
+
+            if (amountSmallerElements > 0) {
+                SortUtils.swap(array, index, index + amountSmallerElements);
+            } else {
+                index++;
             }
         }
 
         return array;
+    }
+
+    private <T extends Comparable<T>> int getSmallerElementCount(T[] array, int index) {
+        int counter = 0;
+        for (int i = index + 1; i < array.length; i++) {
+            if (SortUtils.less(array[i], array[index])) {
+                counter++;
+            }
+        }
+
+        return counter;
     }
 }

--- a/src/main/java/com/thealgorithms/sorts/SwapSort.java
+++ b/src/main/java/com/thealgorithms/sorts/SwapSort.java
@@ -9,64 +9,25 @@ package com.thealgorithms.sorts;
  */
 public class SwapSort implements SortAlgorithm {
 
+    /**
+     * Sorts the input array using the swap sort algorithm.
+     *
+     * @param array the array to be sorted
+     * @param <T>   the type of elements in the array, which must be Comparable
+     * @return the sorted array
+     */
     @Override
     public <T extends Comparable<T>> T[] sort(T[] array) {
         int len = array.length;
-        int index = 0;
 
-        while (index < len - 1) {
-            int amountSmallerElements = this.getSmallerElementCount(array, index);
-
-            if (amountSmallerElements > 0 && index != amountSmallerElements) {
-                SortUtils.swap(array, index, amountSmallerElements);
-            } else {
-                index++;
+        for (int i = 0; i < len - 1; i++) {
+            for (int j = i + 1; j < len; j++) {
+                if (SortUtils.less(array[j], array[i])) {
+                    SortUtils.swap(array, i, j);
+                }
             }
         }
 
         return array;
-    }
-
-    private <T extends Comparable<T>> int getSmallerElementCount(T[] array, int index) {
-        int counter = 0;
-        for (int i = 0; i < array.length; i++) {
-            if (SortUtils.less(array[i], array[index])) {
-                counter++;
-            }
-        }
-
-        return counter;
-    }
-
-    public static void main(String[] args) {
-        // ==== Int =======
-        Integer[] a = {3, 7, 45, 1, 33, 5, 2, 9};
-        System.out.print("unsorted: ");
-        SortUtils.print(a);
-        System.out.println();
-
-        new SwapSort().sort(a);
-        System.out.print("sorted: ");
-        SortUtils.print(a);
-        System.out.println();
-
-        // ==== String =======
-        String[] b = {
-            "banana",
-            "berry",
-            "orange",
-            "grape",
-            "peach",
-            "cherry",
-            "apple",
-            "pineapple",
-        };
-        System.out.print("unsorted: ");
-        SortUtils.print(b);
-        System.out.println();
-
-        new SwapSort().sort(b);
-        System.out.print("sorted: ");
-        SortUtils.print(b);
     }
 }

--- a/src/test/java/com/thealgorithms/sorts/SwapSortTest.java
+++ b/src/test/java/com/thealgorithms/sorts/SwapSortTest.java
@@ -1,0 +1,8 @@
+package com.thealgorithms.sorts;
+
+public class SwapSortTest extends SortingAlgorithmTest {
+    @Override
+    SortAlgorithm getSortAlgorithm() {
+        return new SwapSort();
+    }
+}


### PR DESCRIPTION
There was an issue where this sorting implementation could enter an infinite loop, such as in the test shouldAcceptWhenArrayWithDuplicateValueIsPassed. 

The index variable was not being updated correctly.
The index may never reach len - 1 due to the flawed logic, leading to a potential infinite loop. 

This fix addresses the issue and adds the missing test for this sorting algorithm.

Fixes #5249.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`