### PR TITLE
feat: optimize `SortUtils.swap` by skipping operations for equal indices

### DIFF
--- a/src/main/java/com/thealgorithms/sorts/SortUtils.java
+++ b/src/main/java/com/thealgorithms/sorts/SortUtils.java
@@ -18,7 +18,7 @@ final class SortUtils {
      */
     public static <T> void swap(T[] array, int i, int j) {
         if (i != j) {
-            T temp = array[i];
+            final T temp = array[i];
             array[i] = array[j];
             array[j] = temp;
         }

--- a/src/main/java/com/thealgorithms/sorts/SortUtils.java
+++ b/src/main/java/com/thealgorithms/sorts/SortUtils.java
@@ -17,9 +17,11 @@ final class SortUtils {
      * @param <T>   the type of elements in the array
      */
     public static <T> void swap(T[] array, int i, int j) {
-        T temp = array[i];
-        array[i] = array[j];
-        array[j] = temp;
+        if (i != j) {
+            T temp = array[i];
+            array[i] = array[j];
+            array[j] = temp;
+        }
     }
 
     /**

--- a/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
+++ b/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
@@ -2,7 +2,6 @@ package com.thealgorithms.sorts;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -76,20 +75,21 @@ class SortUtilsTest {
 
     @ParameterizedTest
     @MethodSource("provideArraysForSwap")
-    public <T> void testSwap(T[] array, int i, int j, T[] expected, String message) {
+    public <T> void testSwap(T[] array, int i, int j, T[] expected) {
         SortUtils.swap(array, i, j);
-        assertArrayEquals(expected, array, message);
+        assertArrayEquals(expected, array);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArraysForSwap")
+    public <T> void testSwapFlippedIndices(T[] array, int i, int j, T[] expected) {
+        SortUtils.swap(array, j, i);
+        assertArrayEquals(expected, array);
     }
 
     private static Stream<Arguments> provideArraysForSwap() {
-        return Stream.of(Arguments.of(new Integer[] {1, 2, 3, 4}, 1, 2, new Integer[] {1, 3, 2, 4}, "Swapping adjacent elements should work correctly."), Arguments.of(new Integer[] {1, 2, 3, 4}, 0, 3, new Integer[] {4, 2, 3, 1}, "Swapping non-adjacent elements should work correctly."),
-            Arguments.of(new Integer[] {1, 2, 3, 4}, 2, 2, new Integer[] {1, 2, 3, 4}, "Swapping the same index should not change the array."), Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}, "Swapping first and last elements should work correctly."),
-            Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}, "Swapping null elements should work correctly."), Arguments.of(new Integer[] {}, 0, 0, new Integer[] {}, "Swapping in an empty array should not throw an error."));
-    }
-
-    @Test
-    public void testSwapOutOfBounds() {
-        Integer[] array = {1, 2, 3, 4};
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> SortUtils.swap(array, -1, 4), "Swapping out of bounds should throw an ArrayIndexOutOfBoundsException.");
+        return Stream.of(Arguments.of(new Integer[] {1, 2, 3, 4}, 1, 2, new Integer[] {1, 3, 2, 4}), Arguments.of(new Integer[] {1, 2, 3, 4}, 0, 3, new Integer[] {4, 2, 3, 1}),
+            Arguments.of(new Integer[] {1, 2, 3, 4}, 2, 2, new Integer[] {1, 2, 3, 4}), Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}),
+            Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}), Arguments.of(new Integer[] {}, 0, 0, new Integer[] {}));
     }
 }

--- a/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
+++ b/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
@@ -89,6 +89,6 @@ class SortUtilsTest {
 
     private static Stream<Arguments> provideArraysForSwap() {
         return Stream.of(Arguments.of(new Integer[] {1, 2, 3, 4}, 1, 2, new Integer[] {1, 3, 2, 4}), Arguments.of(new Integer[] {1, 2, 3, 4}, 0, 3, new Integer[] {4, 2, 3, 1}), Arguments.of(new Integer[] {1, 2, 3, 4}, 2, 2, new Integer[] {1, 2, 3, 4}),
-            Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}), Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}), Arguments.of(new Integer[] {}, 0, 0, new Integer[] {}));
+            Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}), Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}));
     }
 }

--- a/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
+++ b/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -83,15 +82,14 @@ class SortUtilsTest {
     }
 
     private static Stream<Arguments> provideArraysForSwap() {
-        return Stream.of(Arguments.of(new Integer[]{1, 2, 3, 4}, 1, 2, new Integer[]{1, 3, 2, 4}, "Swapping adjacent elements should work correctly."), Arguments.of(new Integer[]{1, 2, 3, 4}, 0, 3, new Integer[]{4, 2, 3, 1}, "Swapping non-adjacent elements should work correctly."), Arguments.of(new Integer[]{1, 2, 3, 4}, 2, 2, new Integer[]{1, 2, 3, 4}, "Swapping the same index should not change the array."),
-            Arguments.of(new String[]{"a", "b", "c", "d"}, 0, 3, new String[]{"d", "b", "c", "a"}, "Swapping first and last elements should work correctly."), Arguments.of(new String[]{null, "b", "c", null}, 0, 3, new String[]{null, "b", "c", null}, "Swapping null elements should work correctly."), Arguments.of(new Integer[]{}, 0, 0, new Integer[]{}, "Swapping in an empty array should not throw an error."));
+        return Stream.of(Arguments.of(new Integer[] {1, 2, 3, 4}, 1, 2, new Integer[] {1, 3, 2, 4}, "Swapping adjacent elements should work correctly."), Arguments.of(new Integer[] {1, 2, 3, 4}, 0, 3, new Integer[] {4, 2, 3, 1}, "Swapping non-adjacent elements should work correctly."),
+                Arguments.of(new Integer[] {1, 2, 3, 4}, 2, 2, new Integer[] {1, 2, 3, 4}, "Swapping the same index should not change the array."), Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}, "Swapping first and last elements should work correctly."),
+                Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}, "Swapping null elements should work correctly."), Arguments.of(new Integer[] {}, 0, 0, new Integer[] {}, "Swapping in an empty array should not throw an error."));
     }
 
     @Test
     public void testSwapOutOfBounds() {
         Integer[] array = {1, 2, 3, 4};
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
-            SortUtils.swap(array, -1, 4);
-        }, "Swapping out of bounds should throw an ArrayIndexOutOfBoundsException.");
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> { SortUtils.swap(array, -1, 4); }, "Swapping out of bounds should throw an ArrayIndexOutOfBoundsException.");
     }
 }

--- a/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
+++ b/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
@@ -88,8 +88,7 @@ class SortUtilsTest {
     }
 
     private static Stream<Arguments> provideArraysForSwap() {
-        return Stream.of(Arguments.of(new Integer[] {1, 2, 3, 4}, 1, 2, new Integer[] {1, 3, 2, 4}), Arguments.of(new Integer[] {1, 2, 3, 4}, 0, 3, new Integer[] {4, 2, 3, 1}),
-            Arguments.of(new Integer[] {1, 2, 3, 4}, 2, 2, new Integer[] {1, 2, 3, 4}), Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}),
-            Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}), Arguments.of(new Integer[] {}, 0, 0, new Integer[] {}));
+        return Stream.of(Arguments.of(new Integer[] {1, 2, 3, 4}, 1, 2, new Integer[] {1, 3, 2, 4}), Arguments.of(new Integer[] {1, 2, 3, 4}, 0, 3, new Integer[] {4, 2, 3, 1}), Arguments.of(new Integer[] {1, 2, 3, 4}, 2, 2, new Integer[] {1, 2, 3, 4}),
+            Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}), Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}), Arguments.of(new Integer[] {}, 0, 0, new Integer[] {}));
     }
 }

--- a/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
+++ b/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
@@ -83,13 +83,13 @@ class SortUtilsTest {
 
     private static Stream<Arguments> provideArraysForSwap() {
         return Stream.of(Arguments.of(new Integer[] {1, 2, 3, 4}, 1, 2, new Integer[] {1, 3, 2, 4}, "Swapping adjacent elements should work correctly."), Arguments.of(new Integer[] {1, 2, 3, 4}, 0, 3, new Integer[] {4, 2, 3, 1}, "Swapping non-adjacent elements should work correctly."),
-                Arguments.of(new Integer[] {1, 2, 3, 4}, 2, 2, new Integer[] {1, 2, 3, 4}, "Swapping the same index should not change the array."), Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}, "Swapping first and last elements should work correctly."),
-                Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}, "Swapping null elements should work correctly."), Arguments.of(new Integer[] {}, 0, 0, new Integer[] {}, "Swapping in an empty array should not throw an error."));
+            Arguments.of(new Integer[] {1, 2, 3, 4}, 2, 2, new Integer[] {1, 2, 3, 4}, "Swapping the same index should not change the array."), Arguments.of(new String[] {"a", "b", "c", "d"}, 0, 3, new String[] {"d", "b", "c", "a"}, "Swapping first and last elements should work correctly."),
+            Arguments.of(new String[] {null, "b", "c", null}, 0, 3, new String[] {null, "b", "c", null}, "Swapping null elements should work correctly."), Arguments.of(new Integer[] {}, 0, 0, new Integer[] {}, "Swapping in an empty array should not throw an error."));
     }
 
     @Test
     public void testSwapOutOfBounds() {
         Integer[] array = {1, 2, 3, 4};
-        assertThrows(ArrayIndexOutOfBoundsException.class, () -> { SortUtils.swap(array, -1, 4); }, "Swapping out of bounds should throw an ArrayIndexOutOfBoundsException.");
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> SortUtils.swap(array, -1, 4), "Swapping out of bounds should throw an ArrayIndexOutOfBoundsException.");
     }
 }

--- a/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
+++ b/src/test/java/com/thealgorithms/sorts/SortUtilsTest.java
@@ -1,10 +1,17 @@
 package com.thealgorithms.sorts;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SortUtilsTest {
 
@@ -66,5 +73,25 @@ class SortUtilsTest {
 
         List<Integer> array3 = List.of(5, 4, 3, 2, 1);
         assertFalse(SortUtils.isSorted(array3));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideArraysForSwap")
+    public <T> void testSwap(T[] array, int i, int j, T[] expected, String message) {
+        SortUtils.swap(array, i, j);
+        assertArrayEquals(expected, array, message);
+    }
+
+    private static Stream<Arguments> provideArraysForSwap() {
+        return Stream.of(Arguments.of(new Integer[]{1, 2, 3, 4}, 1, 2, new Integer[]{1, 3, 2, 4}, "Swapping adjacent elements should work correctly."), Arguments.of(new Integer[]{1, 2, 3, 4}, 0, 3, new Integer[]{4, 2, 3, 1}, "Swapping non-adjacent elements should work correctly."), Arguments.of(new Integer[]{1, 2, 3, 4}, 2, 2, new Integer[]{1, 2, 3, 4}, "Swapping the same index should not change the array."),
+            Arguments.of(new String[]{"a", "b", "c", "d"}, 0, 3, new String[]{"d", "b", "c", "a"}, "Swapping first and last elements should work correctly."), Arguments.of(new String[]{null, "b", "c", null}, 0, 3, new String[]{null, "b", "c", null}, "Swapping null elements should work correctly."), Arguments.of(new Integer[]{}, 0, 0, new Integer[]{}, "Swapping in an empty array should not throw an error."));
+    }
+
+    @Test
+    public void testSwapOutOfBounds() {
+        Integer[] array = {1, 2, 3, 4};
+        assertThrows(ArrayIndexOutOfBoundsException.class, () -> {
+            SortUtils.swap(array, -1, 4);
+        }, "Swapping out of bounds should throw an ArrayIndexOutOfBoundsException.");
     }
 }


### PR DESCRIPTION
Adding check if indeces are not equals, for swap method in SortUtils.

According to this suggestion https://github.com/TheAlgorithms/Java/pull/5265#discussion_r1659320131

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`