### PR TITLE
refactor: `StackPostfixNotation`

### DIFF
--- a/src/main/java/com/thealgorithms/stacks/StackPostfixNotation.java
+++ b/src/main/java/com/thealgorithms/stacks/StackPostfixNotation.java
@@ -5,8 +5,15 @@ import java.util.Stack;
 import java.util.function.BiFunction;
 
 /**
- * @brief Utility class evaluating postix expressions, cf. https://en.wikipedia.org/wiki/Reverse_Polish_notation
- * @details The computation is done using Integers.
+ * Utility class for evaluating postfix expressions using integer arithmetic.
+ * <p>
+ * Postfix notation, also known as Reverse Polish Notation (RPN), is a mathematical notation in which operators follow their operands.
+ * This class provides a method to evaluate expressions written in postfix notation.
+ * </p>
+ * <p>
+ * For more information on postfix notation, refer to
+ * <a href="https://en.wikipedia.org/wiki/Reverse_Polish_notation">Reverse Polish Notation (RPN) on Wikipedia</a>.
+ * </p>
  */
 public final class StackPostfixNotation {
     private StackPostfixNotation() {
@@ -55,7 +62,7 @@ public final class StackPostfixNotation {
      * @exception IllegalArgumentException exp is not a valid postix expression.
      */
     public static int postfixEvaluate(final String exp) {
-        Stack<Integer> s = new Stack<Integer>();
+        Stack<Integer> s = new Stack<>();
         consumeExpression(s, exp);
         if (s.size() != 1) {
             throw new IllegalArgumentException("exp is not a proper postfix expression.");

--- a/src/test/java/com/thealgorithms/stacks/StackPostfixNotationTest.java
+++ b/src/test/java/com/thealgorithms/stacks/StackPostfixNotationTest.java
@@ -1,43 +1,31 @@
 package com.thealgorithms.stacks;
 
-import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Map;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class StackPostfixNotationTest {
-    @Test
-    public void testEvaluate() {
-        final Map<String, Integer> testCases = Map.ofEntries(entry("1 1 +", 2), entry("2 3 *", 6), entry("6 2 /", 3), entry("-5 -2 -", -3), entry("5 2 + 3 *", 21), entry("-5", -5));
-        for (final var tc : testCases.entrySet()) {
-            assertEquals(tc.getValue(), StackPostfixNotation.postfixEvaluate(tc.getKey()));
-        }
+
+    @ParameterizedTest
+    @MethodSource("provideValidTestCases")
+    void testEvaluate(String expression, int expected) {
+        assertEquals(expected, StackPostfixNotation.postfixEvaluate(expression));
     }
 
-    @Test
-    public void testIfEvaluateThrowsExceptionForEmptyInput() {
-        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate(""));
+    static Stream<Arguments> provideValidTestCases() {
+        return Stream.of(Arguments.of("1 1 +", 2), Arguments.of("2 3 *", 6), Arguments.of("6 2 /", 3), Arguments.of("-5 -2 -", -3), Arguments.of("5 2 + 3 *", 21), Arguments.of("-5", -5));
     }
 
-    @Test
-    public void testIfEvaluateThrowsExceptionForInproperInput() {
-        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate("3 3 3"));
+    @ParameterizedTest
+    @MethodSource("provideInvalidTestCases")
+    void testEvaluateThrowsException(String expression) {
+        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate(expression));
     }
 
-    @Test
-    public void testIfEvaluateThrowsExceptionForInputWithUnknownOperation() {
-        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate("3 3 !"));
-    }
-
-    @Test
-    public void testIfEvaluateThrowsExceptionForInputWithTooFewArgsA() {
-        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate("+"));
-    }
-
-    @Test
-    public void testIfEvaluateThrowsExceptionForInputWithTooFewArgsB() {
-        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate("2 +"));
+    static Stream<Arguments> provideInvalidTestCases() {return Stream.of(Arguments.of(""), Arguments.of("3 3 3"), Arguments.of("3 3 !"), Arguments.of("+"), Arguments.of("2 +"));
     }
 }

--- a/src/test/java/com/thealgorithms/stacks/StackPostfixNotationTest.java
+++ b/src/test/java/com/thealgorithms/stacks/StackPostfixNotationTest.java
@@ -26,6 +26,7 @@ public class StackPostfixNotationTest {
         assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate(expression));
     }
 
-    static Stream<Arguments> provideInvalidTestCases() {return Stream.of(Arguments.of(""), Arguments.of("3 3 3"), Arguments.of("3 3 !"), Arguments.of("+"), Arguments.of("2 +"));
+    static Stream<Arguments> provideInvalidTestCases() {
+        return Stream.of(Arguments.of(""), Arguments.of("3 3 3"), Arguments.of("3 3 !"), Arguments.of("+"), Arguments.of("2 +"));
     }
 }


### PR DESCRIPTION
Change Map.ofEntries test to Parametrized tests.
Documentation changes.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`