### PR TITLE
fix: `FindKthNumberTest`

### DIFF
--- a/src/test/java/com/thealgorithms/maths/FindKthNumberTest.java
+++ b/src/test/java/com/thealgorithms/maths/FindKthNumberTest.java
@@ -41,14 +41,14 @@ public class FindKthNumberTest {
     @Test
     public void testFindKthMaxLargeArray() {
         int[] array = generateArray(1000);
-        int k = new Random().nextInt(array.length);
+        int k = new Random().nextInt(1, array.length);
         int result = FindKthNumber.findKthMax(array, k);
         Arrays.sort(array);
         assertEquals(array[array.length - k], result);
     }
 
     public static int[] generateArray(int capacity) {
-        int size = new Random().nextInt(capacity) + 1;
+        int size = new Random().nextInt(2, capacity);
         int[] array = new int[size];
 
         for (int i = 0; i < size; i++) {


### PR DESCRIPTION
In some cases, this code generates incorrect arrays, causing the test to not pass. 

The issue happens due to improper constraints on the generated arrays. This was identified in a few previous builds. 

This PR addresses the issue and has been thoroughly tested.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`