### PR TITLE
style: use `getOrDefault` in `MajorityElement`

### DIFF
--- a/src/main/java/com/thealgorithms/datastructures/hashmap/hashing/MajorityElement.java
+++ b/src/main/java/com/thealgorithms/datastructures/hashmap/hashing/MajorityElement.java
@@ -18,17 +18,13 @@ public final class MajorityElement {
    */
     public static List<Integer> majority(int[] nums) {
         HashMap<Integer, Integer> numToCount = new HashMap<>();
-        int n = nums.length;
-        for (int i = 0; i < n; i++) {
-            if (numToCount.containsKey(nums[i])) {
-                numToCount.put(nums[i], numToCount.get(nums[i]) + 1);
-            } else {
-                numToCount.put(nums[i], 1);
-            }
+        for (final var num : nums) {
+            final var curCount = numToCount.getOrDefault(num, 0);
+            numToCount.put(num, curCount + 1);
         }
         List<Integer> majorityElements = new ArrayList<>();
         for (final var entry : numToCount.entrySet()) {
-            if (entry.getValue() >= n / 2) {
+            if (entry.getValue() >= nums.length / 2) {
                 majorityElements.add(entry.getKey());
             }
         }


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

This PR simplifies the logic inside the `majority` method.

The background story is that I was experimenting with [`infer`](https://github.com/facebook/infer) and it was reporting a _potential_ [Null dereference](https://fbinfer.com/docs/all-issue-types/#nullptr_dereference) (there are about 29 left). In this case it will not happen, but the code can be written _better_ (as in this PR). I am considering including infer into our CI. I will keep you updated.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`