### PR TITLE
Add edge case to handle negative rod length in RodCutting algorithm

### DIFF
--- a/src/main/java/com/thealgorithms/dynamicprogramming/RodCutting.java
+++ b/src/main/java/com/thealgorithms/dynamicprogramming/RodCutting.java
@@ -25,6 +25,7 @@ public final class RodCutting {
         if (n < 0) {
             throw new IllegalArgumentException("Rod length cannot be negative.");
         }
+
         // Create an array to store the maximum obtainable values for each rod length.
         int[] val = new int[n + 1];
         val[0] = 0;
@@ -44,3 +45,4 @@ public final class RodCutting {
         return val[n];
     }
 }
+

--- a/src/main/java/com/thealgorithms/dynamicprogramming/RodCutting.java
+++ b/src/main/java/com/thealgorithms/dynamicprogramming/RodCutting.java
@@ -45,4 +45,3 @@ public final class RodCutting {
         return val[n];
     }
 }
-

--- a/src/main/java/com/thealgorithms/dynamicprogramming/RodCutting.java
+++ b/src/main/java/com/thealgorithms/dynamicprogramming/RodCutting.java
@@ -22,6 +22,9 @@ public final class RodCutting {
         if (price == null || price.length == 0) {
             throw new IllegalArgumentException("Price array cannot be null or empty.");
         }
+        if (n < 0) {
+            throw new IllegalArgumentException("Rod length cannot be negative.");
+        }
         // Create an array to store the maximum obtainable values for each rod length.
         int[] val = new int[n + 1];
         val[0] = 0;

--- a/src/test/java/com/thealgorithms/dynamicprogramming/RodCuttingTest.java
+++ b/src/test/java/com/thealgorithms/dynamicprogramming/RodCuttingTest.java
@@ -101,3 +101,4 @@ class RodCuttingTest {
                 "A negative rod length should throw an IllegalArgumentException.");
     }
 }
+

--- a/src/test/java/com/thealgorithms/dynamicprogramming/RodCuttingTest.java
+++ b/src/test/java/com/thealgorithms/dynamicprogramming/RodCuttingTest.java
@@ -93,4 +93,11 @@ class RodCuttingTest {
         int length = 5;
         assertThrows(IllegalArgumentException.class, () -> RodCutting.cutRod(prices, length), "An empty prices array should throw an IllegalArgumentException.");
     }
+    @Test
+    void testCutRodNegativeLength() {
+        int[] prices = {1, 5, 8, 9, 10}; // Prices are irrelevant for negative length
+        int length = -1;
+        assertThrows(IllegalArgumentException.class, () -> RodCutting.cutRod(prices, length),
+                "A negative rod length should throw an IllegalArgumentException.");
+    }
 }

--- a/src/test/java/com/thealgorithms/dynamicprogramming/RodCuttingTest.java
+++ b/src/test/java/com/thealgorithms/dynamicprogramming/RodCuttingTest.java
@@ -97,8 +97,6 @@ class RodCuttingTest {
     void testCutRodNegativeLength() {
         int[] prices = {1, 5, 8, 9, 10}; // Prices are irrelevant for negative length
         int length = -1;
-        assertThrows(IllegalArgumentException.class, () -> RodCutting.cutRod(prices, length),
-                "A negative rod length should throw an IllegalArgumentException.");
+        assertThrows(IllegalArgumentException.class, () -> RodCutting.cutRod(prices, length), "A negative rod length should throw an IllegalArgumentException.");
     }
 }
-


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`