### PR TITLE
Update Armstrong.java

### DIFF
--- a/src/main/java/com/thealgorithms/maths/Armstrong.java
+++ b/src/main/java/com/thealgorithms/maths/Armstrong.java
@@ -21,16 +21,14 @@ public class Armstrong {
      */
     public boolean isArmstrong(int number) {
         long sum = 0;
-        String temp = Integer.toString(number); // Convert the given number to a string
-        int power = temp.length(); // Extract the length of the number (number of digits)
+        int totalDigits = (int) Math.log10(number) + 1;; // get the length of the number (number of digits)
         long originalNumber = number;
 
         while (originalNumber > 0) {
             long digit = originalNumber % 10;
-            sum += (long) Math.pow(digit, power); // The digit raised to the power of the number of digits and added to the sum.
+            sum += (long) Math.pow(digit, totalDigits); // The digit raised to the power of the number of digits and added to the sum.
             originalNumber /= 10;
         }
-
         return sum == number;
     }
 }


### PR DESCRIPTION
Optimized Armstrong number check by removing string conversion
This update optimizes the Armstrong number check by eliminating the need for string conversion to calculate the number of digits. Instead, the number of digits is calculated using the Math.log10() function. This change improves both performance and readability, as we now compute the number of digits in a more efficient manner without converting the number to a string.

Changes made:
Removed string conversion (Integer.toString()) for calculating the number of digits.
Replaced it with a mathematical approach using Math.log10(num) + 1 to determine the number of digits in the given number.
The logic remains the same for summing each digit raised to the power of the number of digits.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [ ] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`