### PR TITLE
Fix AbsoluteMax bug for equal absolute values

### DIFF
--- a/src/main/java/com/thealgorithms/maths/AbsoluteMax.java
+++ b/src/main/java/com/thealgorithms/maths/AbsoluteMax.java
@@ -17,7 +17,7 @@ public final class AbsoluteMax {
         }
         int absMax = numbers[0];
         for (int i = 1; i < numbers.length; i++) {
-            if (Math.abs(numbers[i]) > Math.abs(absMax)) {
+            if (Math.abs(numbers[i]) > Math.abs(absMax) || (Math.abs(numbers[i]) == Math.abs(absMax) && numbers[i] > absMax)) {
                 absMax = numbers[i];
             }
         }

--- a/src/test/java/com/thealgorithms/maths/AbsoluteMaxTest.java
+++ b/src/test/java/com/thealgorithms/maths/AbsoluteMaxTest.java
@@ -19,4 +19,13 @@ public class AbsoluteMaxTest {
     void testGetMaxValueWithNoArguments() {
         assertThrows(IllegalArgumentException.class, AbsoluteMax::getMaxValue);
     }
+
+    @Test
+    void testGetMaxValueWithSameAbsoluteValues() {
+        assertEquals(5, AbsoluteMax.getMaxValue(-5, 5));
+        assertEquals(5, AbsoluteMax.getMaxValue(5, -5));
+        assertEquals(12, AbsoluteMax.getMaxValue(-12, 9, 3, 12, 1));
+        assertEquals(12, AbsoluteMax.getMaxValue(12, 9, 3, -12, 1));
+    }
+
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->
The AbsoluteMax class contains a bug in the getMaxValue method. When two numbers have the same absolute value (e.g., 5 and -5), the method returns the number that appears later in the array. This behavior is inconsistent and may lead to unexpected results.

Explanation with Example.

Before Fix
5, -5 returns -5 
-5, 5 returns  5

After Fix
5, -5 returns  5 
-5, 5 returns  5



<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`

Thanks