### PR TITLE
style: do not suppress `lossy-conversions`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
                         <arg>-Xlint:-auxiliaryclass</arg>
                         <arg>-Xlint:-rawtypes</arg>
                         <arg>-Xlint:-unchecked</arg>
-                        <arg>-Xlint:-lossy-conversions</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>

--- a/src/main/java/com/thealgorithms/ciphers/Caesar.java
+++ b/src/main/java/com/thealgorithms/ciphers/Caesar.java
@@ -9,6 +9,9 @@ package com.thealgorithms.ciphers;
  * @author khalil2535
  */
 public class Caesar {
+    private static char normalizeShift(final int shift) {
+        return (char) (shift % 26);
+    }
 
     /**
      * Encrypt text by shifting every Latin char by add number shift for ASCII
@@ -19,7 +22,7 @@ public class Caesar {
     public String encode(String message, int shift) {
         StringBuilder encoded = new StringBuilder();
 
-        shift %= 26;
+        final char shiftChar = normalizeShift(shift);
 
         final int length = message.length();
         for (int i = 0; i < length; i++) {
@@ -29,10 +32,10 @@ public class Caesar {
             char current = message.charAt(i); // Java law : char + int = char
 
             if (isCapitalLatinLetter(current)) {
-                current += shift;
+                current += shiftChar;
                 encoded.append((char) (current > 'Z' ? current - 26 : current)); // 26 = number of latin letters
             } else if (isSmallLatinLetter(current)) {
-                current += shift;
+                current += shiftChar;
                 encoded.append((char) (current > 'z' ? current - 26 : current)); // 26 = number of latin letters
             } else {
                 encoded.append(current);
@@ -50,16 +53,16 @@ public class Caesar {
     public String decode(String encryptedMessage, int shift) {
         StringBuilder decoded = new StringBuilder();
 
-        shift %= 26;
+        final char shiftChar = normalizeShift(shift);
 
         final int length = encryptedMessage.length();
         for (int i = 0; i < length; i++) {
             char current = encryptedMessage.charAt(i);
             if (isCapitalLatinLetter(current)) {
-                current -= shift;
+                current -= shiftChar;
                 decoded.append((char) (current < 'A' ? current + 26 : current)); // 26 = number of latin letters
             } else if (isSmallLatinLetter(current)) {
-                current -= shift;
+                current -= shiftChar;
                 decoded.append((char) (current < 'a' ? current + 26 : current)); // 26 = number of latin letters
             } else {
                 decoded.append(current);

--- a/src/main/java/com/thealgorithms/maths/AliquotSum.java
+++ b/src/main/java/com/thealgorithms/maths/AliquotSum.java
@@ -56,7 +56,7 @@ public final class AliquotSum {
         // if n is a perfect square then its root was added twice in above loop, so subtracting root
         // from sum
         if (root == (int) root) {
-            sum -= root;
+            sum -= (int) root;
         }
         return sum;
     }

--- a/src/main/java/com/thealgorithms/maths/PerfectNumber.java
+++ b/src/main/java/com/thealgorithms/maths/PerfectNumber.java
@@ -63,7 +63,7 @@ public final class PerfectNumber {
         // if n is a perfect square then its root was added twice in above loop, so subtracting root
         // from sum
         if (root == (int) root) {
-            sum -= root;
+            sum -= (int) root;
         }
 
         return sum == n;


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

This PR _includes_ `lossy-conversions` into the active compiler warnings.

Continuation of #5165.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`