### PR TITLE
fix: use last known working commit for infer to avoid build failure

### DIFF
--- a/.github/workflows/infer.yml
+++ b/.github/workflows/infer.yml
@@ -41,6 +41,7 @@ jobs:
           cd ..
           git clone https://github.com/facebook/infer.git
           cd infer
+          git checkout 01aaa268f9d38723ba69c139e10f9e2a04b40b1c
           ./build-infer.sh java
           cp -r infer ../Java
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`

The current build of facebook/infer is failing ([see](https://github.com/facebook/infer/commit/dc195a4eae2859d6367bb4afd1495ce1cdadd07e)) , which causes our GitHub Actions workflow to fail as well. To temporarily stabilize our CI pipeline, this PR pins facebook/infer to the last known working commit.

Once the upstream issue is resolved and the build is stable again, I will update our workflow to use the latest version and open a new Pull Request accordingly.