### PR TITLE
chore: suppress `rawtypes` in selected classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
                         <arg>-Xlint:-auxiliaryclass</arg>
-                        <arg>-Xlint:-rawtypes</arg>
                         <arg>-Xlint:-unchecked</arg>
                         <arg>-Werror</arg>
                     </compilerArgs>

--- a/src/main/java/com/thealgorithms/backtracking/AllPathsFromSourceToTarget.java
+++ b/src/main/java/com/thealgorithms/backtracking/AllPathsFromSourceToTarget.java
@@ -9,6 +9,7 @@ import java.util.List;
  *
  * @author <a href="https://github.com/siddhant2002">Siddhant Swarup Mallick</a>
  */
+@SuppressWarnings("rawtypes")
 public class AllPathsFromSourceToTarget {
 
     // No. of vertices in graph

--- a/src/main/java/com/thealgorithms/datastructures/bloomfilter/BloomFilter.java
+++ b/src/main/java/com/thealgorithms/datastructures/bloomfilter/BloomFilter.java
@@ -12,6 +12,7 @@ import java.util.BitSet;
  *
  * @param <T> The type of elements to be stored in the Bloom filter.
  */
+@SuppressWarnings("rawtypes")
 public class BloomFilter<T> {
 
     private final int numberOfHashFunctions;

--- a/src/main/java/com/thealgorithms/datastructures/graphs/Kruskal.java
+++ b/src/main/java/com/thealgorithms/datastructures/graphs/Kruskal.java
@@ -19,6 +19,7 @@ import java.util.PriorityQueue;
  *
  * <p><strong>Time Complexity:</strong> O(E log V), where E is the number of edges and V is the number of vertices.</p>
  */
+@SuppressWarnings("rawtypes")
 public class Kruskal {
 
     /**

--- a/src/main/java/com/thealgorithms/datastructures/graphs/WelshPowell.java
+++ b/src/main/java/com/thealgorithms/datastructures/graphs/WelshPowell.java
@@ -22,6 +22,7 @@ import java.util.stream.IntStream;
  * For more information, see <a href="https://en.wikipedia.org/wiki/Graph_coloring">Graph Coloring</a>.
  * </p>
  */
+@SuppressWarnings("rawtypes")
 public final class WelshPowell {
     private static final int BLANK_COLOR = -1; // Constant representing an uncolored state
 

--- a/src/main/java/com/thealgorithms/datastructures/hashmap/hashing/GenericHashMapUsingArray.java
+++ b/src/main/java/com/thealgorithms/datastructures/hashmap/hashing/GenericHashMapUsingArray.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
  * @param <K> the type of keys maintained by this hash map
  * @param <V> the type of mapped values
  */
+@SuppressWarnings("rawtypes")
 public class GenericHashMapUsingArray<K, V> {
 
     private int size; // Total number of key-value pairs

--- a/src/main/java/com/thealgorithms/datastructures/hashmap/hashing/HashMap.java
+++ b/src/main/java/com/thealgorithms/datastructures/hashmap/hashing/HashMap.java
@@ -8,6 +8,7 @@ package com.thealgorithms.datastructures.hashmap.hashing;
  * @param <K> the type of keys maintained by this map
  * @param <V> the type of mapped values
  */
+@SuppressWarnings("rawtypes")
 public class HashMap<K, V> {
     private final int hashSize;
     private final LinkedList<K, V>[] buckets;

--- a/src/main/java/com/thealgorithms/datastructures/hashmap/hashing/LinearProbingHashMap.java
+++ b/src/main/java/com/thealgorithms/datastructures/hashmap/hashing/LinearProbingHashMap.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
  * @param <Key> the type of keys maintained by this map
  * @param <Value> the type of mapped values
  */
+@SuppressWarnings("rawtypes")
 public class LinearProbingHashMap<Key extends Comparable<Key>, Value> extends Map<Key, Value> {
     private int hsize; // size of the hash table
     private Key[] keys; // array to store keys

--- a/src/main/java/com/thealgorithms/datastructures/lists/CircleLinkedList.java
+++ b/src/main/java/com/thealgorithms/datastructures/lists/CircleLinkedList.java
@@ -10,6 +10,7 @@ package com.thealgorithms.datastructures.lists;
  *
  * @param <E> the type of elements held in this list
  */
+@SuppressWarnings("rawtypes")
 public class CircleLinkedList<E> {
 
     /**

--- a/src/main/java/com/thealgorithms/datastructures/lists/CursorLinkedList.java
+++ b/src/main/java/com/thealgorithms/datastructures/lists/CursorLinkedList.java
@@ -10,6 +10,7 @@ import java.util.Objects;
  *
  * @param <T> the type of elements in this list
  */
+@SuppressWarnings("rawtypes")
 public class CursorLinkedList<T> {
 
     /**

--- a/src/main/java/com/thealgorithms/datastructures/lists/SkipList.java
+++ b/src/main/java/com/thealgorithms/datastructures/lists/SkipList.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
  * @param <E> type of elements
  * @see <a href="https://en.wikipedia.org/wiki/Skip_list">Wiki. Skip list</a>
  */
+@SuppressWarnings("rawtypes")
 public class SkipList<E extends Comparable<E>> {
 
     /**

--- a/src/main/java/com/thealgorithms/dynamicprogramming/LongestArithmeticSubsequence.java
+++ b/src/main/java/com/thealgorithms/dynamicprogramming/LongestArithmeticSubsequence.java
@@ -2,6 +2,7 @@ package com.thealgorithms.dynamicprogramming;
 
 import java.util.HashMap;
 
+@SuppressWarnings("rawtypes")
 final class LongestArithmeticSubsequence {
     private LongestArithmeticSubsequence() {
     }

--- a/src/main/java/com/thealgorithms/misc/PalindromeSinglyLinkedList.java
+++ b/src/main/java/com/thealgorithms/misc/PalindromeSinglyLinkedList.java
@@ -10,6 +10,7 @@ import java.util.Stack;
  * See more:
  * https://www.geeksforgeeks.org/function-to-check-if-a-singly-linked-list-is-palindrome/
  */
+@SuppressWarnings("rawtypes")
 public final class PalindromeSinglyLinkedList {
     private PalindromeSinglyLinkedList() {
     }

--- a/src/main/java/com/thealgorithms/searches/FibonacciSearch.java
+++ b/src/main/java/com/thealgorithms/searches/FibonacciSearch.java
@@ -15,6 +15,7 @@ import com.thealgorithms.devutils.searches.SearchAlgorithm;
  * Note: This algorithm requires that the input array be sorted.
  * </p>
  */
+@SuppressWarnings("rawtypes")
 public class FibonacciSearch implements SearchAlgorithm {
 
     /**

--- a/src/main/java/com/thealgorithms/sorts/MergeSort.java
+++ b/src/main/java/com/thealgorithms/sorts/MergeSort.java
@@ -7,6 +7,7 @@ import static com.thealgorithms.sorts.SortUtils.less;
  *
  * @see SortAlgorithm
  */
+@SuppressWarnings("rawtypes")
 class MergeSort implements SortAlgorithm {
 
     private Comparable[] aux;

--- a/src/main/java/com/thealgorithms/sorts/SortAlgorithm.java
+++ b/src/main/java/com/thealgorithms/sorts/SortAlgorithm.java
@@ -8,6 +8,7 @@ import java.util.List;
  *
  * @author Podshivalov Nikita (https://github.com/nikitap492)
  */
+@SuppressWarnings("rawtypes")
 public interface SortAlgorithm {
     /**
      * Main method arrays sorting algorithms

--- a/src/main/java/com/thealgorithms/sorts/SpreadSort.java
+++ b/src/main/java/com/thealgorithms/sorts/SpreadSort.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
  * It distributes elements into buckets and recursively sorts these buckets.
  * This implementation is generic and can sort any array of elements that extend Comparable.
  */
+@SuppressWarnings("rawtypes")
 public class SpreadSort implements SortAlgorithm {
     private static final int MAX_INSERTION_SORT_THRESHOLD = 1000;
     private static final int MAX_INITIAL_BUCKET_CAPACITY = 1000;

--- a/src/main/java/com/thealgorithms/sorts/TimSort.java
+++ b/src/main/java/com/thealgorithms/sorts/TimSort.java
@@ -7,6 +7,7 @@ import static com.thealgorithms.sorts.SortUtils.less;
  * <p>
  * For more details @see <a href="https://en.wikipedia.org/wiki/Timsort">TimSort Algorithm</a>
  */
+@SuppressWarnings("rawtypes")
 class TimSort implements SortAlgorithm {
     private static final int SUB_ARRAY_SIZE = 32;
     private Comparable[] aux;

--- a/src/test/java/com/thealgorithms/datastructures/graphs/KruskalTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/graphs/KruskalTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("rawtypes")
 public class KruskalTest {
 
     private Kruskal kruskal;

--- a/src/test/java/com/thealgorithms/maths/NumberOfDigitsTest.java
+++ b/src/test/java/com/thealgorithms/maths/NumberOfDigitsTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@SuppressWarnings("rawtypes")
 public class NumberOfDigitsTest {
 
     @ParameterizedTest


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

This PR includes `rawtypes` into the active compiler warnings and suppresses it for the classes causing problems.

I see the following advantages:
- all remaining code (including potential new code) will be compiled with this warning enabled,
- it allows to split the task of resolving all of these warnings into reasonable chunks.

If this will be merged, I will create similar pull requests for the remaining warnings, i.e. `auxiliaryclass` and `unchecked`.

Continuation of #5165.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`