### PR TITLE
Added ToggleKthBit algorithm in bitmanipulation with unit tests. The method toggles the K-th bit of a number using bitwise XOR. Includes an example and JavaDoc.

### DIFF
--- a/src/main/java/com/thealgorithms/bitmanipulation/GenerateSubsets.java
+++ b/src/main/java/com/thealgorithms/bitmanipulation/GenerateSubsets.java
@@ -1,5 +1,6 @@
 package com.thealgorithms.bitmanipulation;
 
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/thealgorithms/bitmanipulation/ToggleKthBit.java
+++ b/src/main/java/com/thealgorithms/bitmanipulation/ToggleKthBit.java
@@ -2,14 +2,14 @@ package com.thealgorithms.bitmanipulation;
 
 /**
  * The ToggleKthBit class provides a method to toggle the K-th bit of a given number.
- * 
+ *
  * Toggling means: if the K-th bit is 1, it becomes 0; if it's 0, it becomes 1.
- * 
+ *
  * Example:
  *   Input: n = 10 (1010 in binary), k = 1
  *   Output: 8  (1000 in binary)
- * 
- * @author Rahul 
+ *
+ * @author Rahul
  */
 public final class ToggleKthBit {
 

--- a/src/main/java/com/thealgorithms/bitmanipulation/ToggleKthBit.java
+++ b/src/main/java/com/thealgorithms/bitmanipulation/ToggleKthBit.java
@@ -1,0 +1,30 @@
+package com.thealgorithms.bitmanipulation;
+
+/**
+ * The ToggleKthBit class provides a method to toggle the K-th bit of a given number.
+ * 
+ * Toggling means: if the K-th bit is 1, it becomes 0; if it's 0, it becomes 1.
+ * 
+ * Example:
+ *   Input: n = 10 (1010 in binary), k = 1
+ *   Output: 8  (1000 in binary)
+ * 
+ * @author Rahul 
+ */
+public final class ToggleKthBit {
+
+    private ToggleKthBit() {
+        // Utility class, no need to instantiate
+    }
+
+    /**
+     * Toggles the K-th bit (0-based index from right) of a number.
+     *
+     * @param n the number to toggle the bit in
+     * @param k the position of the bit to toggle (0-based)
+     * @return the number after toggling the K-th bit
+     */
+    public static int toggleKthBit(int n, int k) {
+        return n ^ (1 << k);
+    }
+}

--- a/src/test/java/com/thealgorithms/bitmanipulation/ToggleKthBitTest.java
+++ b/src/test/java/com/thealgorithms/bitmanipulation/ToggleKthBitTest.java
@@ -1,0 +1,15 @@
+package com.thealgorithms.bitmanipulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+
+public class ToggleKthBitTest {
+
+    @Test
+    public void testToggleKthBit() {
+        assertEquals(8, ToggleKthBit.toggleKthBit(10, 1));  // 1010 ^ (1<<1) = 1000
+        assertEquals(14, ToggleKthBit.toggleKthBit(10, 2)); // 1010 ^ (1<<2) = 1110
+        assertEquals(2, ToggleKthBit.toggleKthBit(0, 1));   // 0000 ^ (1<<1) = 0010
+        assertEquals(0, ToggleKthBit.toggleKthBit(1, 0));   // 0001 ^ (1<<0) = 0000
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`