### PR TITLE
chore: perform CodeQL scan on actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,12 +10,9 @@ on:
   schedule:
     - cron: '53 3 * * 0'
 
-env:
-  LANGUAGE: 'java-kotlin'
-
 jobs:
-  analyze:
-    name: Analyze
+  analyzeJava:
+    name: AnalyzeJava
     runs-on: 'ubuntu-latest'
     permissions:
       actions: read
@@ -35,7 +32,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          languages: ${{ env.LANGUAGE }}
+          languages: 'java-kotlin'
 
       - name: Build
         run: mvn --batch-mode --update-snapshots verify
@@ -43,5 +40,27 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
         with:
-          category: "/language:${{env.LANGUAGE}}"
+          category: "/language:java-kotlin"
+
+  analyzeActions:
+    name: AnalyzeActions
+    runs-on: 'ubuntu-latest'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: 'actions'
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:actions"
 ...


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

This PR configures the CodeQL scan to take care of the potential vulnerabilities in the github actions. When this will be merged, 5 _security alerts_ will be created in [`security/code-scanning`](https://github.com/TheAlgorithms/Java/security/code-scanning). I will take cake of them (they are all related to setting permissions, the fix is similar to vil02/adv_2024#184).

Continuation of #4966.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`