### PR TITLE
refactor: adding docs for `LongestCommonPrefixTest` and Parameterized Tests

### DIFF
--- a/src/main/java/com/thealgorithms/strings/LongestCommonPrefix.java
+++ b/src/main/java/com/thealgorithms/strings/LongestCommonPrefix.java
@@ -2,21 +2,42 @@ package com.thealgorithms.strings;
 
 import java.util.Arrays;
 
+/**
+ * Utility class for string operations.
+ * <p>
+ * This class provides a method to find the longest common prefix (LCP)
+ * among an array of strings.
+ * </p>
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Longest_common_prefix">Longest Common Prefix - Wikipedia</a>
+ */
 public final class LongestCommonPrefix {
-    public String longestCommonPrefix(String[] strs) {
+
+    private LongestCommonPrefix() {
+    }
+
+    /**
+     * Finds the longest common prefix among a list of strings using lexicographical sorting.
+     * The prefix is common to the first and last elements after sorting the array.
+     *
+     * @param strs array of input strings
+     * @return the longest common prefix, or empty string if none exists
+     */
+    public static String longestCommonPrefix(String[] strs) {
         if (strs == null || strs.length == 0) {
             return "";
         }
 
         Arrays.sort(strs);
-        String shortest = strs[0];
-        String longest = strs[strs.length - 1];
+        String first = strs[0];
+        String last = strs[strs.length - 1];
 
         int index = 0;
-        while (index < shortest.length() && index < longest.length() && shortest.charAt(index) == longest.charAt(index)) {
+        while (index < first.length() && index < last.length() &&
+                first.charAt(index) == last.charAt(index)) {
             index++;
         }
 
-        return shortest.substring(0, index);
+        return first.substring(0, index);
     }
 }

--- a/src/main/java/com/thealgorithms/strings/LongestCommonPrefix.java
+++ b/src/main/java/com/thealgorithms/strings/LongestCommonPrefix.java
@@ -33,8 +33,7 @@ public final class LongestCommonPrefix {
         String last = strs[strs.length - 1];
 
         int index = 0;
-        while (index < first.length() && index < last.length() &&
-                first.charAt(index) == last.charAt(index)) {
+        while (index < first.length() && index < last.length() && first.charAt(index) == last.charAt(index)) {
             index++;
         }
 

--- a/src/test/java/com/thealgorithms/strings/LongestCommonPrefixTest.java
+++ b/src/test/java/com/thealgorithms/strings/LongestCommonPrefixTest.java
@@ -2,72 +2,22 @@ package com.thealgorithms.strings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.DisplayName;
 
 public class LongestCommonPrefixTest {
 
-    private final LongestCommonPrefix longestCommonPrefix = new LongestCommonPrefix();
-
-    @Test
-    public void testCommonPrefix() {
-        String[] input = {"flower", "flow", "flight"};
-        String expected = "fl";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
+    @ParameterizedTest(name = "{index} => input={0}, expected=\"{1}\"")
+    @MethodSource("provideTestCases")
+    @DisplayName("Test Longest Common Prefix")
+    void testLongestCommonPrefix(String[] input, String expected) {
+        assertEquals(expected, LongestCommonPrefix.longestCommonPrefix(input));
     }
 
-    @Test
-    public void testNoCommonPrefix() {
-        String[] input = {"dog", "racecar", "car"};
-        String expected = "";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
-    }
-
-    @Test
-    public void testEmptyArray() {
-        String[] input = {};
-        String expected = "";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
-    }
-
-    @Test
-    public void testNullArray() {
-        String[] input = null;
-        String expected = "";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
-    }
-
-    @Test
-    public void testSingleString() {
-        String[] input = {"single"};
-        String expected = "single";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
-    }
-
-    @Test
-    public void testCommonPrefixWithDifferentLengths() {
-        String[] input = {"ab", "a"};
-        String expected = "a";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
-    }
-
-    @Test
-    public void testAllSameStrings() {
-        String[] input = {"test", "test", "test"};
-        String expected = "test";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
-    }
-
-    @Test
-    public void testPrefixAtEnd() {
-        String[] input = {"abcde", "abcfgh", "abcmnop"};
-        String expected = "abc";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
-    }
-
-    @Test
-    public void testMixedCase() {
-        String[] input = {"Flower", "flow", "flight"};
-        String expected = "";
-        assertEquals(expected, longestCommonPrefix.longestCommonPrefix(input));
+    private static Stream<Arguments> provideTestCases() {
+        return Stream.of(Arguments.of(new String[]{"flower", "flow", "flight"}, "fl"), Arguments.of(new String[]{"dog", "racecar", "car"}, ""), Arguments.of(new String[]{}, ""), Arguments.of(null, ""), Arguments.of(new String[]{"single"}, "single"), Arguments.of(new String[]{"ab", "a"}, "a"), Arguments.of(new String[]{"test", "test", "test"}, "test"), Arguments.of(new String[]{"abcde", "abcfgh", "abcmnop"}, "abc"), Arguments.of(new String[]{"Flower", "flow", "flight"}, ""));
     }
 }

--- a/src/test/java/com/thealgorithms/strings/LongestCommonPrefixTest.java
+++ b/src/test/java/com/thealgorithms/strings/LongestCommonPrefixTest.java
@@ -3,10 +3,10 @@ package com.thealgorithms.strings;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.DisplayName;
 
 public class LongestCommonPrefixTest {
 
@@ -18,6 +18,7 @@ public class LongestCommonPrefixTest {
     }
 
     private static Stream<Arguments> provideTestCases() {
-        return Stream.of(Arguments.of(new String[]{"flower", "flow", "flight"}, "fl"), Arguments.of(new String[]{"dog", "racecar", "car"}, ""), Arguments.of(new String[]{}, ""), Arguments.of(null, ""), Arguments.of(new String[]{"single"}, "single"), Arguments.of(new String[]{"ab", "a"}, "a"), Arguments.of(new String[]{"test", "test", "test"}, "test"), Arguments.of(new String[]{"abcde", "abcfgh", "abcmnop"}, "abc"), Arguments.of(new String[]{"Flower", "flow", "flight"}, ""));
+        return Stream.of(Arguments.of(new String[] {"flower", "flow", "flight"}, "fl"), Arguments.of(new String[] {"dog", "racecar", "car"}, ""), Arguments.of(new String[] {}, ""), Arguments.of(null, ""), Arguments.of(new String[] {"single"}, "single"), Arguments.of(new String[] {"ab", "a"}, "a"),
+            Arguments.of(new String[] {"test", "test", "test"}, "test"), Arguments.of(new String[] {"abcde", "abcfgh", "abcmnop"}, "abc"), Arguments.of(new String[] {"Flower", "flow", "flight"}, ""));
     }
 }


### PR DESCRIPTION
- Refactored LongestCommonPrefixTest to use JUnit 5 @ParameterizedTest with @MethodSource for cleaner and more maintainable test cases.

- Improved readability by including input/output context in test names.

- Preserved all original test logic while consolidating and simplifying the structure.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`