### PR TITLE
testing: added unit tests for the `BinaryPow.binPow`

### DIFF
--- a/src/test/java/com/thealgorithms/maths/BinaryPowTest.java
+++ b/src/test/java/com/thealgorithms/maths/BinaryPowTest.java
@@ -13,4 +13,34 @@ public class BinaryPowTest {
         assertEquals(729, BinaryPow.binPow(9, 3));
         assertEquals(262144, BinaryPow.binPow(8, 6));
     }
+
+    @Test
+    void testZeroExponent() {
+        assertEquals(1, BinaryPow.binPow(2, 0));
+        assertEquals(1, BinaryPow.binPow(100, 0));
+        assertEquals(1, BinaryPow.binPow(-5, 0));
+    }
+
+    @Test
+    void testZeroBase() {
+        assertEquals(0, BinaryPow.binPow(0, 5));
+        assertEquals(1, BinaryPow.binPow(0, 0));
+    }
+
+    @Test
+    void testOneBase() {
+        assertEquals(1, BinaryPow.binPow(1, 100));
+        assertEquals(1, BinaryPow.binPow(1, 0));
+    }
+
+    @Test
+    void testNegativeBase() {
+        assertEquals(-8, BinaryPow.binPow(-2, 3));
+        assertEquals(16, BinaryPow.binPow(-2, 4));
+    }
+
+    @Test
+    void testLargeExponent() {
+        assertEquals(1073741824, BinaryPow.binPow(2, 30));
+    }
 }


### PR DESCRIPTION
Added unit tests for the BinaryPow.binPow method to validate correctness across edge cases, including:
- Zero exponent
- Zero base (including 0^0)
- One as base
- Negative bases with odd/even exponents
- Large exponent scenario

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`