### PR TITLE
Add HashSet data structure implementation for integers (#6304)

### DIFF
--- a/src/main/java/com/thealgorithms/datastructures/hashset/HashSet.java
+++ b/src/main/java/com/thealgorithms/datastructures/hashset/HashSet.java
@@ -27,9 +27,9 @@ public class HashSet {
 
     @SuppressWarnings("unchecked")
     public HashSet() {
-        buckets = new LinkedList[INITIAL_CAPACITY];
+        buckets = (LinkedList<Integer>[]) new LinkedList[INITIAL_CAPACITY];
         for (int i = 0; i < INITIAL_CAPACITY; i++) {
-            buckets[i] = new LinkedList<>();
+            buckets[i] = new LinkedList<Integer>();
         }
         size = 0;
     }


### PR DESCRIPTION
This PR adds a simple implementation of a HashSet data structure for integers using separate chaining with linked lists.

Provides methods for add, remove, contains, and size.
Includes a usage example in the class-level JavaDoc.
Closes #6304.

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`