### PR TITLE
testing: improving `GenerateSubsetsTest`

### DIFF
--- a/src/test/java/com/thealgorithms/recursion/GenerateSubsetsTest.java
+++ b/src/test/java/com/thealgorithms/recursion/GenerateSubsetsTest.java
@@ -33,7 +33,7 @@ public final class GenerateSubsetsTest {
         assertSubsets("", List.of(""));
     }
 
-    private void assertSubsets(String input, List<String> expected) {
+    private void assertSubsets(String input, Iterable<String> expected) {
         List<String> actual = GenerateSubsets.subsetRecursion(input);
         assertIterableEquals(expected, actual, "Subsets do not match for input: " + input);
     }

--- a/src/test/java/com/thealgorithms/recursion/GenerateSubsetsTest.java
+++ b/src/test/java/com/thealgorithms/recursion/GenerateSubsetsTest.java
@@ -1,36 +1,40 @@
 package com.thealgorithms.recursion;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
+import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public final class GenerateSubsetsTest {
 
     @Test
-    void subsetRecursionTestOne() {
-        String str = "abc";
-        String[] expected = new String[] {"abc", "ab", "ac", "a", "bc", "b", "c", ""};
-
-        List<String> ans = GenerateSubsets.subsetRecursion(str);
-        assertArrayEquals(ans.toArray(), expected);
+    @DisplayName("Subsets of 'abc'")
+    void testSubsetsOfABC() {
+        assertSubsets("abc", Arrays.asList("abc", "ab", "ac", "a", "bc", "b", "c", ""));
     }
 
     @Test
-    void subsetRecursionTestTwo() {
-        String str = "cbf";
-        String[] expected = new String[] {"cbf", "cb", "cf", "c", "bf", "b", "f", ""};
-
-        List<String> ans = GenerateSubsets.subsetRecursion(str);
-        assertArrayEquals(ans.toArray(), expected);
+    @DisplayName("Subsets of 'cbf'")
+    void testSubsetsOfCBF() {
+        assertSubsets("cbf", Arrays.asList("cbf", "cb", "cf", "c", "bf", "b", "f", ""));
     }
 
     @Test
-    void subsetRecursionTestThree() {
-        String str = "aba";
-        String[] expected = new String[] {"aba", "ab", "aa", "a", "ba", "b", "a", ""};
+    @DisplayName("Subsets of 'aba' with duplicates")
+    void testSubsetsWithDuplicateChars() {
+        assertSubsets("aba", Arrays.asList("aba", "ab", "aa", "a", "ba", "b", "a", ""));
+    }
 
-        List<String> ans = GenerateSubsets.subsetRecursion(str);
-        assertArrayEquals(ans.toArray(), expected);
+    @Test
+    @DisplayName("Subsets of empty string")
+    void testEmptyInput() {
+        assertSubsets("", List.of(""));
+    }
+
+    private void assertSubsets(String input, List<String> expected) {
+        List<String> actual = GenerateSubsets.subsetRecursion(input);
+        assertIterableEquals(expected, actual, "Subsets do not match for input: " + input);
     }
 }


### PR DESCRIPTION
Refactored GenerateSubsetsTest for clarity and maintainability.
- Improved test names and added @DisplayName
- Added edge case test for empty input
- Reduced duplication using helper method
- Cleaner assertions with assertIterableEquals

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`