### PR TITLE
testing: improve `CircularBufferTest`

### DIFF
--- a/src/test/java/com/thealgorithms/datastructures/buffers/CircularBufferTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/buffers/CircularBufferTest.java
@@ -2,7 +2,6 @@ package com.thealgorithms.datastructures.buffers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -68,11 +67,11 @@ class CircularBufferTest {
 
     @Test
     void testIllegalArguments() {
-        assertThrows(IllegalArgumentException.class, () -> new CircularBuffer<>(0));
-        assertThrows(IllegalArgumentException.class, () -> new CircularBuffer<>(-1));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> new CircularBuffer<>(0));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> new CircularBuffer<>(-1));
 
         CircularBuffer<String> buffer = new CircularBuffer<>(1);
-        assertThrows(IllegalArgumentException.class, () -> buffer.put(null));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> buffer.put(null));
     }
 
     @Test
@@ -84,5 +83,150 @@ class CircularBufferTest {
         assertTrue(buffer.isFull());
         buffer.put(1000); // This should overwrite 0
         assertEquals(1, buffer.get());
+    }
+
+    @Test
+    void testPutAfterGet() {
+        CircularBuffer<Integer> buffer = new CircularBuffer<>(2);
+        buffer.put(10);
+        buffer.put(20);
+        assertEquals(10, buffer.get());
+        buffer.put(30);
+        assertEquals(20, buffer.get());
+        assertEquals(30, buffer.get());
+        assertNull(buffer.get());
+    }
+
+    @Test
+    void testMultipleWrapArounds() {
+        CircularBuffer<Integer> buffer = new CircularBuffer<>(3);
+        for (int i = 1; i <= 6; i++) {
+            buffer.put(i);
+            buffer.get(); // add and immediately remove
+        }
+        assertTrue(buffer.isEmpty());
+        assertNull(buffer.get());
+    }
+
+    @Test
+    void testOverwriteMultipleTimes() {
+        CircularBuffer<String> buffer = new CircularBuffer<>(2);
+        buffer.put("X");
+        buffer.put("Y");
+        buffer.put("Z"); // overwrites "X"
+        buffer.put("W"); // overwrites "Y"
+        assertEquals("Z", buffer.get());
+        assertEquals("W", buffer.get());
+        assertNull(buffer.get());
+    }
+
+    @Test
+    void testIsEmptyAndIsFullTransitions() {
+        CircularBuffer<Integer> buffer = new CircularBuffer<>(2);
+        assertTrue(buffer.isEmpty());
+        org.junit.jupiter.api.Assertions.assertFalse(buffer.isFull());
+
+        buffer.put(1);
+        org.junit.jupiter.api.Assertions.assertFalse(buffer.isEmpty());
+        org.junit.jupiter.api.Assertions.assertFalse(buffer.isFull());
+
+        buffer.put(2);
+        assertTrue(buffer.isFull());
+
+        buffer.get();
+        org.junit.jupiter.api.Assertions.assertFalse(buffer.isFull());
+
+        buffer.get();
+        assertTrue(buffer.isEmpty());
+    }
+
+    @Test
+    void testInterleavedPutAndGet() {
+        CircularBuffer<String> buffer = new CircularBuffer<>(3);
+        buffer.put("A");
+        buffer.put("B");
+        assertEquals("A", buffer.get());
+        buffer.put("C");
+        assertEquals("B", buffer.get());
+        assertEquals("C", buffer.get());
+        assertNull(buffer.get());
+    }
+
+    @Test
+    void testRepeatedNullInsertionThrows() {
+        CircularBuffer<Object> buffer = new CircularBuffer<>(5);
+        for (int i = 0; i < 3; i++) {
+            int finalI = i;
+            org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> buffer.put(null), "Iteration: " + finalI);
+        }
+    }
+    @Test
+    void testFillThenEmptyThenReuseBuffer() {
+        CircularBuffer<Integer> buffer = new CircularBuffer<>(3);
+
+        buffer.put(1);
+        buffer.put(2);
+        buffer.put(3);
+        assertTrue(buffer.isFull());
+
+        assertEquals(1, buffer.get());
+        assertEquals(2, buffer.get());
+        assertEquals(3, buffer.get());
+
+        assertTrue(buffer.isEmpty());
+
+        buffer.put(4);
+        buffer.put(5);
+        assertEquals(4, buffer.get());
+        assertEquals(5, buffer.get());
+        assertTrue(buffer.isEmpty());
+    }
+
+    @Test
+    void testPutReturnsTrueOnlyIfPreviouslyEmpty() {
+        CircularBuffer<String> buffer = new CircularBuffer<>(2);
+
+        assertTrue(buffer.put("one"));  // was empty
+        org.junit.jupiter.api.Assertions.assertFalse(buffer.put("two")); // not empty
+        org.junit.jupiter.api.Assertions.assertFalse(buffer.put("three")); // overwrite
+    }
+
+    @Test
+    void testOverwriteAndGetAllElementsCorrectly() {
+        CircularBuffer<Integer> buffer = new CircularBuffer<>(3);
+
+        buffer.put(1);
+        buffer.put(2);
+        buffer.put(3);
+        buffer.put(4); // Overwrites 1
+        buffer.put(5); // Overwrites 2
+
+        assertEquals(3, buffer.get());
+        assertEquals(4, buffer.get());
+        assertEquals(5, buffer.get());
+        assertNull(buffer.get());
+    }
+
+    @Test
+    void testBufferWithOneElementCapacity() {
+        CircularBuffer<String> buffer = new CircularBuffer<>(1);
+
+        assertTrue(buffer.put("first"));
+        assertEquals("first", buffer.get());
+        assertNull(buffer.get());
+
+        assertTrue(buffer.put("second"));
+        assertEquals("second", buffer.get());
+    }
+
+    @Test
+    void testPointerWraparoundWithExactMultipleOfCapacity() {
+        CircularBuffer<Integer> buffer = new CircularBuffer<>(3);
+        for (int i = 0; i < 6; i++) {
+            buffer.put(i);
+            buffer.get(); // keep buffer size at 0
+        }
+        assertTrue(buffer.isEmpty());
+        assertNull(buffer.get());
     }
 }

--- a/src/test/java/com/thealgorithms/datastructures/buffers/CircularBufferTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/buffers/CircularBufferTest.java
@@ -186,7 +186,7 @@ class CircularBufferTest {
     void testPutReturnsTrueOnlyIfPreviouslyEmpty() {
         CircularBuffer<String> buffer = new CircularBuffer<>(2);
 
-        assertTrue(buffer.put("one"));  // was empty
+        assertTrue(buffer.put("one")); // was empty
         org.junit.jupiter.api.Assertions.assertFalse(buffer.put("two")); // not empty
         org.junit.jupiter.api.Assertions.assertFalse(buffer.put("three")); // overwrite
     }


### PR DESCRIPTION
Improvements:

- Edge cases covered: single-element buffer, empty/full transitions, null handling.
- Pointer wraparound verified: multiple cycles and overwrites tested.
- Overwrite logic validated: ensures correct item order after overwriting.
- Buffer reusability: confirmed after full drain/refill.
- Return values of put(): tested for both empty and full states.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`