### PR TITLE
testing: improve `DisjointSetUnionTest`

### DIFF
--- a/src/test/java/com/thealgorithms/datastructures/disjointsetunion/DisjointSetUnionTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/disjointsetunion/DisjointSetUnionTest.java
@@ -129,7 +129,6 @@ public class DisjointSetUnionTest {
         Node<Integer> node1 = dsu.makeSet(1);
         Node<Integer> node2 = dsu.makeSet(2);
         Node<Integer> node3 = dsu.makeSet(3);
-        Node<Integer> node4 = dsu.makeSet(4);
 
         // Create tree with node1 as root and rank 1
         dsu.unionSets(node1, node2);

--- a/src/test/java/com/thealgorithms/datastructures/disjointsetunion/DisjointSetUnionTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/disjointsetunion/DisjointSetUnionTest.java
@@ -122,4 +122,110 @@ public class DisjointSetUnionTest {
         assertEquals(root, node1);
         assertEquals(node1, node3.parent);
     }
+
+    @Test
+    public void testUnionByRankSmallerToLarger() {
+        DisjointSetUnion<Integer> dsu = new DisjointSetUnion<>();
+        Node<Integer> node1 = dsu.makeSet(1);
+        Node<Integer> node2 = dsu.makeSet(2);
+        Node<Integer> node3 = dsu.makeSet(3);
+        Node<Integer> node4 = dsu.makeSet(4);
+
+        // Create tree with node1 as root and rank 1
+        dsu.unionSets(node1, node2);
+        assertEquals(1, node1.rank);
+        assertEquals(0, node2.rank);
+
+        // Union single node (rank 0) with tree (rank 1)
+        // Smaller rank tree should attach to larger rank tree
+        dsu.unionSets(node3, node1);
+        assertEquals(node1, dsu.findSet(node3));
+        assertEquals(1, node1.rank); // Rank should not increase
+    }
+
+    @Test
+    public void testUnionByRankEqualRanks() {
+        DisjointSetUnion<Integer> dsu = new DisjointSetUnion<>();
+        Node<Integer> node1 = dsu.makeSet(1);
+        Node<Integer> node2 = dsu.makeSet(2);
+        Node<Integer> node3 = dsu.makeSet(3);
+        Node<Integer> node4 = dsu.makeSet(4);
+
+        // Create two trees of equal rank (1)
+        dsu.unionSets(node1, node2);
+        dsu.unionSets(node3, node4);
+        assertEquals(1, node1.rank);
+        assertEquals(1, node3.rank);
+
+        // Union two trees of equal rank
+        dsu.unionSets(node1, node3);
+        Node<Integer> root = dsu.findSet(node1);
+        assertEquals(2, root.rank); // Rank should increase by 1
+    }
+
+    @Test
+    public void testLargeChainPathCompression() {
+        DisjointSetUnion<Integer> dsu = new DisjointSetUnion<>();
+        Node<Integer> node1 = dsu.makeSet(1);
+        Node<Integer> node2 = dsu.makeSet(2);
+        Node<Integer> node3 = dsu.makeSet(3);
+        Node<Integer> node4 = dsu.makeSet(4);
+        Node<Integer> node5 = dsu.makeSet(5);
+
+        // Create a long chain: 1 -> 2 -> 3 -> 4 -> 5
+        dsu.unionSets(node1, node2);
+        dsu.unionSets(node2, node3);
+        dsu.unionSets(node3, node4);
+        dsu.unionSets(node4, node5);
+
+        // Find from the deepest node
+        Node<Integer> root = dsu.findSet(node5);
+
+        // Path compression should make all nodes point directly to root
+        assertEquals(root, node5.parent);
+        assertEquals(root, node4.parent);
+        assertEquals(root, node3.parent);
+        assertEquals(root, node2.parent);
+        assertEquals(root, node1.parent);
+    }
+
+    @Test
+    public void testMultipleDisjointSets() {
+        DisjointSetUnion<Integer> dsu = new DisjointSetUnion<>();
+        Node<Integer> node1 = dsu.makeSet(1);
+        Node<Integer> node2 = dsu.makeSet(2);
+        Node<Integer> node3 = dsu.makeSet(3);
+        Node<Integer> node4 = dsu.makeSet(4);
+        Node<Integer> node5 = dsu.makeSet(5);
+        Node<Integer> node6 = dsu.makeSet(6);
+
+        // Create two separate components
+        dsu.unionSets(node1, node2);
+        dsu.unionSets(node2, node3);
+
+        dsu.unionSets(node4, node5);
+        dsu.unionSets(node5, node6);
+
+        // Verify they are separate
+        assertEquals(dsu.findSet(node1), dsu.findSet(node2));
+        assertEquals(dsu.findSet(node2), dsu.findSet(node3));
+        assertEquals(dsu.findSet(node4), dsu.findSet(node5));
+        assertEquals(dsu.findSet(node5), dsu.findSet(node6));
+
+        assertNotEquals(dsu.findSet(node1), dsu.findSet(node4));
+        assertNotEquals(dsu.findSet(node3), dsu.findSet(node6));
+    }
+
+    @Test
+    public void testEmptyValues() {
+        DisjointSetUnion<String> dsu = new DisjointSetUnion<>();
+        Node<String> emptyNode = dsu.makeSet("");
+        Node<String> nullNode = dsu.makeSet(null);
+
+        assertEquals(emptyNode, dsu.findSet(emptyNode));
+        assertEquals(nullNode, dsu.findSet(nullNode));
+
+        dsu.unionSets(emptyNode, nullNode);
+        assertEquals(dsu.findSet(emptyNode), dsu.findSet(nullNode));
+    }
 }


### PR DESCRIPTION
Added test cases for DisjointSetUnion:
- testUnionByRankSmallerToLarger - Validates union-by-rank optimization
- testUnionByRankEqualRanks - Tests rank increment for equal-rank unions
- testLargeChainPathCompression - Verifies path compression works correctly
- testMultipleDisjointSets - Tests separate component isolation
- testEmptyValues - Tests null/empty string handling

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`