### PR TITLE
#6336/enhancement/Refactor: Standardize comparison logic using SortUtils

### DIFF
--- a/src/main/java/com/thealgorithms/sorts/AdaptiveMergeSort.java
+++ b/src/main/java/com/thealgorithms/sorts/AdaptiveMergeSort.java
@@ -30,7 +30,7 @@ public class AdaptiveMergeSort implements SortAlgorithm {
                 array[k] = aux[j++];
             } else if (j > high) {
                 array[k] = aux[i++];
-            } else if (aux[j].compareTo(aux[i]) < 0) {
+            } else if (SortUtils.less(aux[j], aux[i])) {
                 array[k] = aux[j++];
             } else {
                 array[k] = aux[i++];

--- a/src/main/java/com/thealgorithms/sorts/BinaryInsertionSort.java
+++ b/src/main/java/com/thealgorithms/sorts/BinaryInsertionSort.java
@@ -22,7 +22,7 @@ public class BinaryInsertionSort implements SortAlgorithm {
 
             while (low <= high) {
                 final int mid = (low + high) >>> 1;
-                if (temp.compareTo(array[mid]) < 0) {
+                if (SortUtils.less(temp, array[mid])) {
                     high = mid - 1;
                 } else {
                     low = mid + 1;

--- a/src/main/java/com/thealgorithms/sorts/BitonicSort.java
+++ b/src/main/java/com/thealgorithms/sorts/BitonicSort.java
@@ -64,7 +64,7 @@ public class BitonicSort implements SortAlgorithm {
         if (cnt > 1) {
             final int k = cnt / 2;
 
-            final BiPredicate<T, T> areSorted = (direction == Direction.ASCENDING) ? (a, b) -> a.compareTo(b) < 0 : (a, b) -> a.compareTo(b) > 0;
+            final BiPredicate<T, T> areSorted = (direction == Direction.ASCENDING) ? (a, b) -> (SortUtils.less(a, b)) : (a, b) -> (SortUtils.greater(a, b));
             for (int i = low; i < low + k; i++) {
                 if (!areSorted.test(array[i], array[i + k])) {
                     SortUtils.swap(array, i, i + k);

--- a/src/main/java/com/thealgorithms/sorts/BucketSort.java
+++ b/src/main/java/com/thealgorithms/sorts/BucketSort.java
@@ -111,7 +111,7 @@ public class BucketSort implements SortAlgorithm {
     private <T extends Comparable<T>> T findMin(T[] array) {
         T min = array[0];
         for (T element : array) {
-            if (element.compareTo(min) < 0) {
+            if (SortUtils.less(element, min)) {
                 min = element;
             }
         }
@@ -121,7 +121,7 @@ public class BucketSort implements SortAlgorithm {
     private <T extends Comparable<T>> T findMax(T[] array) {
         T max = array[0];
         for (T element : array) {
-            if (element.compareTo(max) > 0) {
+            if (SortUtils.greater(element,max)) {
                 max = element;
             }
         }

--- a/src/main/java/com/thealgorithms/sorts/BucketSort.java
+++ b/src/main/java/com/thealgorithms/sorts/BucketSort.java
@@ -121,7 +121,7 @@ public class BucketSort implements SortAlgorithm {
     private <T extends Comparable<T>> T findMax(T[] array) {
         T max = array[0];
         for (T element : array) {
-            if (SortUtils.greater(element,max)) {
+            if (SortUtils.greater(element, max)) {
                 max = element;
             }
         }

--- a/src/main/java/com/thealgorithms/sorts/CircleSort.java
+++ b/src/main/java/com/thealgorithms/sorts/CircleSort.java
@@ -36,7 +36,7 @@ public class CircleSort implements SortAlgorithm {
         int high = right;
 
         while (low < high) {
-            if (array[low].compareTo(array[high]) > 0) {
+            if (SortUtils.greater(array[low], array[high])) {
                 SortUtils.swap(array, low, high);
                 swapped = true;
             }
@@ -44,7 +44,7 @@ public class CircleSort implements SortAlgorithm {
             high--;
         }
 
-        if (low == high && array[low].compareTo(array[high + 1]) > 0) {
+        if (low == high && (SortUtils.greater(array[low], array[high + 1]))) {
             SortUtils.swap(array, low, high + 1);
             swapped = true;
         }

--- a/src/main/java/com/thealgorithms/sorts/DutchNationalFlagSort.java
+++ b/src/main/java/com/thealgorithms/sorts/DutchNationalFlagSort.java
@@ -26,11 +26,11 @@ public class DutchNationalFlagSort implements SortAlgorithm {
         int k = array.length - 1;
 
         while (j <= k) {
-            if (0 > array[j].compareTo(intendedMiddle)) {
+            if (SortUtils.less(array[j], intendedMiddle)) {
                 SortUtils.swap(array, i, j);
                 j++;
                 i++;
-            } else if (0 < array[j].compareTo(intendedMiddle)) {
+            } else if (SortUtils.greater(array[j], intendedMiddle)) {
                 SortUtils.swap(array, j, k);
                 k--;
             } else {

--- a/src/main/java/com/thealgorithms/sorts/ExchangeSort.java
+++ b/src/main/java/com/thealgorithms/sorts/ExchangeSort.java
@@ -31,7 +31,7 @@ class ExchangeSort implements SortAlgorithm {
     public <T extends Comparable<T>> T[] sort(T[] array) {
         for (int i = 0; i < array.length - 1; i++) {
             for (int j = i + 1; j < array.length; j++) {
-                if (array[i].compareTo(array[j]) > 0) {
+                if (SortUtils.greater(array[i], array[j])){
                     SortUtils.swap(array, i, j);
                 }
             }

--- a/src/main/java/com/thealgorithms/sorts/ExchangeSort.java
+++ b/src/main/java/com/thealgorithms/sorts/ExchangeSort.java
@@ -31,7 +31,7 @@ class ExchangeSort implements SortAlgorithm {
     public <T extends Comparable<T>> T[] sort(T[] array) {
         for (int i = 0; i < array.length - 1; i++) {
             for (int j = i + 1; j < array.length; j++) {
-                if (SortUtils.greater(array[i], array[j])){
+                if (SortUtils.greater(array[i], array[j])) {
                     SortUtils.swap(array, i, j);
                 }
             }

--- a/src/main/java/com/thealgorithms/sorts/IntrospectiveSort.java
+++ b/src/main/java/com/thealgorithms/sorts/IntrospectiveSort.java
@@ -63,7 +63,7 @@ public class IntrospectiveSort implements SortAlgorithm {
         final T pivot = array[high];
         int i = low - 1;
         for (int j = low; j < high; j++) {
-            if (array[j].compareTo(pivot) <= 0) {
+            if (SortUtils.greaterOrEqual(pivot, array[j])) {
                 i++;
                 SortUtils.swap(array, i, j);
             }
@@ -84,7 +84,7 @@ public class IntrospectiveSort implements SortAlgorithm {
         for (int i = low + 1; i <= high; i++) {
             final T key = array[i];
             int j = i - 1;
-            while (j >= low && array[j].compareTo(key) > 0) {
+            while (j >= low && (SortUtils.greater(array[j], key))) {
                 array[j + 1] = array[j];
                 j--;
             }
@@ -125,10 +125,10 @@ public class IntrospectiveSort implements SortAlgorithm {
         final int right = 2 * i + 2;
         int largest = i;
 
-        if (left < n && array[low + left].compareTo(array[low + largest]) > 0) {
+        if (left < n && (SortUtils.greater(array[low + left], array[low + largest]))) {
             largest = left;
         }
-        if (right < n && array[low + right].compareTo(array[low + largest]) > 0) {
+        if (right < n && (SortUtils.greater(array[low + right], array[low + largest]))) {
             largest = right;
         }
         if (largest != i) {

--- a/src/main/java/com/thealgorithms/sorts/OddEvenSort.java
+++ b/src/main/java/com/thealgorithms/sorts/OddEvenSort.java
@@ -30,7 +30,7 @@ public final class OddEvenSort implements SortAlgorithm {
     private <T extends Comparable<T>> boolean performOddSort(T[] array) {
         boolean sorted = true;
         for (int i = 1; i < array.length - 1; i += 2) {
-            if (array[i].compareTo(array[i + 1]) > 0) {
+            if (SortUtils.greater(array[i], array[i + 1])) {
                 SortUtils.swap(array, i, i + 1);
                 sorted = false;
             }
@@ -41,7 +41,7 @@ public final class OddEvenSort implements SortAlgorithm {
     private <T extends Comparable<T>> boolean performEvenSort(T[] array) {
         boolean sorted = true;
         for (int i = 0; i < array.length - 1; i += 2) {
-            if (array[i].compareTo(array[i + 1]) > 0) {
+            if (SortUtils.greater(array[i], array[i + 1])) {
                 SortUtils.swap(array, i, i + 1);
                 sorted = false;
             }

--- a/src/main/java/com/thealgorithms/sorts/SelectionSort.java
+++ b/src/main/java/com/thealgorithms/sorts/SelectionSort.java
@@ -21,7 +21,7 @@ public class SelectionSort implements SortAlgorithm {
     private static <T extends Comparable<T>> int findIndexOfMin(T[] array, final int startIndex) {
         int minIndex = startIndex;
         for (int i = startIndex + 1; i < array.length; i++) {
-            if (array[i].compareTo(array[minIndex]) < 0) {
+            if (SortUtils.less(array[i], array[minIndex])) {
                 minIndex = i;
             }
         }

--- a/src/main/java/com/thealgorithms/sorts/SelectionSortRecursive.java
+++ b/src/main/java/com/thealgorithms/sorts/SelectionSortRecursive.java
@@ -56,6 +56,6 @@ public class SelectionSortRecursive implements SortAlgorithm {
         final int minIndexInRest = findMinIndex(array, start + 1);
 
         // Return the index of the smaller element between array[start] and the minimum element in the rest of the array
-        return array[start].compareTo(array[minIndexInRest]) < 0 ? start : minIndexInRest;
+        return (SortUtils.less(array[start], array[minIndexInRest])) ? start : minIndexInRest;
     }
 }

--- a/src/main/java/com/thealgorithms/sorts/StalinSort.java
+++ b/src/main/java/com/thealgorithms/sorts/StalinSort.java
@@ -8,7 +8,7 @@ public class StalinSort implements SortAlgorithm {
         }
         int currentIndex = 0;
         for (int i = 1; i < array.length; i++) {
-            if (array[i].compareTo(array[currentIndex]) >= 0) {
+            if (SortUtils.greaterOrEqual(array[i], array[currentIndex])) {
                 currentIndex++;
                 array[currentIndex] = array[i];
             }


### PR DESCRIPTION
Enhancement https://github.com/TheAlgorithms/Java/issues/6336

I have refactored and replaced all the compareTo with SortUtil functions. The places where equality is checked or where the code uses the values given by the compareTo() , has not been replaced.

Three files have no changes and the reason is mentioned below:

StrandSort : In this java class the methods in which compareTo is used has <T extends Comparable<? super T>> as the return type. Since the SortUtils functions are declared with <T extends Comparable>, which contradicts. Thus SortUtils functions cannot be used here in this class in any method.
FlashSort : same reason as StrandSort
WiggleSort: This class either has equality or it uses the numerical value given by the compareTo().
Thus apart from above three classes all other classes have been refcatored.

👍 I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
👍 This pull request is all my own work -- I have not plagiarized it.
👍 All filenames are in PascalCase.
👍 All functions and variable names follow Java naming conventions.
👍 All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
👍 All new code is formatted with clang-format -i --style=file path/to/your/file.java