### PR TITLE
Fix/convex hull order

### DIFF
--- a/src/main/java/com/thealgorithms/geometry/ConvexHull.java
+++ b/src/main/java/com/thealgorithms/geometry/ConvexHull.java
@@ -85,6 +85,7 @@ public final class ConvexHull {
         }
         
         // Implementation of Graham's scan algorithm to ensure CCW order
+        // See: https://en.wikipedia.org/wiki/Graham_scan
         // Find the bottom-most, left-most point
         Point start = Collections.min(points);
         // Sort points by polar angle with respect to start


### PR DESCRIPTION
Implemented Graham's scan algorithm to ensure convex hull points are returned in CCW order. This fixes issues with downstream algorithms like Rotating Calipers that require properly ordered hull vertices.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`