### PR TITLE
Add Infix to Postfix conversion using Stack

### DIFF
--- a/src/main/java/com/thealgorithms/stacks/Infix-To-Postfix(using stack lib)
+++ b/src/main/java/com/thealgorithms/stacks/Infix-To-Postfix(using stack lib)
@@ -1,0 +1,70 @@
+// InfixToPostfix.java
+// Program to convert Infix expression to Postfix using Stack
+// Time Complexity: O(n)
+// Space Complexity: O(n)
+
+import java.util.Stack;
+
+public class InfixToPostfix {
+
+    // Function to define operator precedence
+    static int precedence(char op) {
+        if (op == '+' || op == '-') return 1;
+        if (op == '*' || op == '/') return 2;
+        if (op == '^') return 3;
+        return 0;
+    }
+
+    // Function to check if a character is an operator
+    static boolean isOperator(char c) {
+        return (c == '+' || c == '-' || c == '*' || c == '/' || c == '^');
+    }
+
+    // Function to convert infix to postfix
+    static String infixToPostfix(String infix) {
+        Stack<Character> stack = new Stack<>();
+        StringBuilder postfix = new StringBuilder();
+
+        for (int i = 0; i < infix.length(); i++) {
+            char c = infix.charAt(i);
+
+            // If operand, add it to output
+            if (Character.isLetterOrDigit(c)) {
+                postfix.append(c);
+            }
+            // If '(', push to stack
+            else if (c == '(') {
+                stack.push(c);
+            }
+            // If ')', pop until '('
+            else if (c == ')') {
+                while (!stack.isEmpty() && stack.peek() != '(') {
+                    postfix.append(stack.pop());
+                }
+                stack.pop(); // remove '('
+            }
+            // If operator
+            else if (isOperator(c)) {
+                while (!stack.isEmpty() && precedence(stack.peek()) >= precedence(c)) {
+                    postfix.append(stack.pop());
+                }
+                stack.push(c);
+            }
+        }
+
+        // Pop remaining operators
+        while (!stack.isEmpty()) {
+            postfix.append(stack.pop());
+        }
+
+        return postfix.toString();
+    }
+
+    // Main function
+    public static void main(String[] args) {
+        String infix = "A+B*C-D";
+        System.out.println("Infix Expression: " + infix);
+        String postfix = infixToPostfix(infix);
+        System.out.println("Postfix Expression: " + postfix);
+    }
+}


### PR DESCRIPTION
Fixes #6638 


This program converts infix expressions to postfix notation using a stack. It includes operator precedence handling and supports basic arithmetic operators.
Input:
String infix = "A+B*C-D";
Output:
Infix Expression: A+B*C-D
Postfix Expression: ABC*+D-






<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [ ] This pull request is all my own work -- I have not plagiarized it.
- [ ] All filenames are in PascalCase.
- [ ] All functions and variable names follow Java naming conventions.
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [ ] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`