### PR TITLE
Add Infix to Postfix conversion implementation

### DIFF
--- a/src/main/java/com/thealgorithms/stacks/InfixToPostfixevaluator.java
+++ b/src/main/java/com/thealgorithms/stacks/InfixToPostfixevaluator.java
@@ -1,0 +1,69 @@
+import java.util.Stack;
+
+public class InfixToPostfix {
+    
+    // Function to check operator precedence
+    static int precedence(char ch) {
+        switch (ch) {
+            case '+':
+            case '-':
+                return 1;
+            case '*':
+            case '/':
+                return 2;
+            case '^':
+                return 3;
+        }
+        return -1;
+    }
+
+    // Function to convert infix to postfix
+    static String convert(String expression) {
+        String result = "";
+        Stack<Character> stack = new Stack<>();
+
+        for (int i = 0; i < expression.length(); i++) {
+            char c = expression.charAt(i);
+
+            // If character is an operand, add it to output
+            if (Character.isLetterOrDigit(c)) {
+                result += c;
+            }
+
+            // If character is '(', push it to stack
+            else if (c == '(') {
+                stack.push(c);
+            }
+
+            // If character is ')', pop until '(' is found
+            else if (c == ')') {
+                while (!stack.isEmpty() && stack.peek() != '(') {
+                    result += stack.pop();
+                }
+                stack.pop(); // remove '('
+            }
+
+            // If character is operator
+            else {
+                while (!stack.isEmpty() && precedence(c) <= precedence(stack.peek())) {
+                    result += stack.pop();
+                }
+                stack.push(c);
+            }
+        }
+
+        // Pop all remaining operators from stack
+        while (!stack.isEmpty()) {
+            result += stack.pop();
+        }
+
+        return result;
+    }
+
+    // Main method to test the program
+    public static void main(String[] args) {
+        String infix = "A*(B+C)/D";
+        System.out.println("Infix: " + infix);
+        System.out.println("Postfix: " + convert(infix));
+    }
+}


### PR DESCRIPTION

Fix #6655 
Infix Expression: Operator is between operands → A + B

Postfix Expression: Operator is after operands → A B +

We use a stack to temporarily hold operators and handle operator precedence.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`