### PR TITLE
docs: add templates & clarify local development guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -1,0 +1,23 @@
+---
+name: Good first issue
+about: Use this template for beginner-friendly tasks in TheAlgorithms/Java.
+title: "good first issue: <short summary>"
+labels: ["good first issue","help wanted"]
+assignees: []
+---
+
+### Summary
+(Short one-line description of what needs to be done)
+
+### Why this helps
+(Explain how this improves the repo or assists contributors.)
+
+### Acceptance criteria
+- [ ] What success looks like.
+
+### Steps / guidance
+1. Path(s) of files to update (e.g., `README.md`, `src/...`).
+2. Branch naming: `fix/your-name-shortdesc`.
+3. Local test: `mvn test` or `./gradlew test` (if applicable).
+
+Feel free to comment if you need help getting started.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+(One-sentence summary of your change.)
+
+## What changed / fixed
+- Reference issue: Closes #<issue-number> (if any)
+- Short description of the change
+
+## How I tested
+- Commands you ran (e.g., `mvn test`, `./gradlew build`, or doc changes only).
+- If docs only: say that.
+
+## Checklist
+- [ ] My changes are focused and small
+- [ ] I followed CONTRIBUTING.md guidelines
+- [ ] I ran lint/tests (if applicable)
+- [ ] Screenshots added (if UI or docs include images)
+
+## Notes to maintainers
+(Any extra context)

--- a/README.md
+++ b/README.md
@@ -18,3 +18,23 @@ Please read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute
 
 ## Algorithms
 Our [directory](DIRECTORY.md) has the full list of applications.
+
+### Local development & contributing
+
+1. Clone & build
+\`\`\`bash
+git clone https://github.com/TheAlgorithms/Java.git
+cd Java
+mvn test   # or ./gradlew test if using Gradle
+\`\`\`
+
+2. Troubleshooting & tips
+- Ensure Java 11+ is installed (see `pom.xml`).
+- If tests fail: try: `mvn clean install`.
+- For large builds: use `-DskipTests` when building and run tests separately.
+- Contributions: add Javadoc, follow package structure, add tests for new algorithms.
+
+3. How to get started
+- Look for issues labelled `good first issue` (once template is active).
+- Fork → branch → PR as per templates above.
+


### PR DESCRIPTION
This is a documentation-only PR to improve contributor onboarding for TheAlgorithms/Java:

- Adds `.github/ISSUE_TEMPLATE/good-first-issue.md` to help new contributors find tasks.
- Adds `.github/PULL_REQUEST_TEMPLATE.md` to standardize PRs.
- Appends a Local Development & contributing block to README.md.

Why:
- Low-risk, high-value changes to make it easier to contribute and speed up reviews.

How I tested:
- Docs-only; verified files updated locally.

Notes:
- Happy to adjust wording per maintainers' preferences.
