### PR TITLE
docs: Update CONTRIBUTING.md to reference Discord instead of Gitter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,5 @@ NOTE: *Please avoid opening issues asking to be "assigned" to a particular algor
 
 ### Do you have questions about the source code?
 
-- Ask any question about how to use the repository in the [TheAlgorithms room in GITTER](https://gitter.im/TheAlgorithms/community?source=orgpage#) or [open a new issue](https://github.com/TheAlgorithms/Java/issues/new)
-
+  - Ask any question about how to use the repository in the [TheAlgorithms community on Discord](https://discord.gg/c7MnfGFGa6) or [open a new issue]
 :+1::tada: That's all you need to know about the process now it's your turn to help us improve the repository, thank you again! :+1::tada:


### PR DESCRIPTION
Fixes #7105

The CONTRIBUTING.md file currently references "TheAlgorithms room in GITTER" for community questions, but the repository has migrated to Discord for community communication. Updated the reference to point to the Discord community instead.