### PR TITLE
Correct Javadoc return description for cylinder surface area

### DIFF
--- a/src/main/java/com/thealgorithms/maths/Area.java
+++ b/src/main/java/com/thealgorithms/maths/Area.java
@@ -89,8 +89,7 @@ public final class Area {
      *
      * @param radius radius of the floor
      * @param height height of the cylinder.
-     * @return volume of given cylinder
-     */
+surface area     */
     public static double surfaceAreaCylinder(final double radius, final double height) {
         if (radius <= 0) {
             throw new IllegalArgumentException(POSITIVE_RADIUS);


### PR DESCRIPTION
## Description
Fixed incorrect Javadoc return description for the `surfaceAreaCylinder` method.

## Changes
- Changed `@return volume of given cylinder` to `@return surface area of given cylinder`

The method calculates surface area, not volume, so the javadoc was misleading.