### PR TITLE
Update Javadoc for perimeterIrregularPolygon method

### DIFF
--- a/src/main/java/com/thealgorithms/maths/Perimeter.java
+++ b/src/main/java/com/thealgorithms/maths/Perimeter.java
@@ -27,7 +27,7 @@ public final class Perimeter {
      * @param side2 for length of side 2
      * @param side3 for length of side 3
      * @param sides for length of remaining sides
-     * @return Perimeter of given trapezoid.
+     * @return Perimeter of given irregular polygon.
      */
     public static float perimeterIrregularPolygon(float side1, float side2, float side3, float... sides) {
         float perimeter = side1 + side2 + side3;


### PR DESCRIPTION
Fixed incorrect @return description in perimeterIrregularPolygon method javadoc. Changed "trapezoid" to "irregular polygon" to accurately reflect what the method calculates.

<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->

<!-- For completed items, change [ ] to [x] -->

- [ ] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [ ] This pull request is all my own work -- I have not plagiarized it.
- [ ] All filenames are in PascalCase.
- [ ] All functions and variable names follow Java naming conventions.
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [ ] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`