### PR TITLE
Document consistent directory naming for search and sort algorithms

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -1,3 +1,15 @@
+
+## Naming Conventions
+
+All algorithm categories use lowercase, plural directory names that match their Java packages.  
+For example:
+- Searching algorithms are in `searches` (`com.thealgorithms.searches`)
+- Sorting algorithms are in `sorts` (`com.thealgorithms.sorts`)
+
+This avoids older mixed forms like `Search/`, `searching/`, or `sort/` and keeps the structure consistent for contributors.
+
+
+
 # Project Structure
 
 ## src


### PR DESCRIPTION
This PR addresses the directory naming inconsistency mentioned in Issue #3 (use of `Search/`, `searching/`, and `sort/` in older documentation).

The current codebase already uses standardized, lowercase plural package names:
- `searches` (`com.thealgorithms.searches`)
- `sorts` (`com.thealgorithms.sorts`)

To make this convention explicit for contributors and prevent future inconsistencies, I added a "Naming Conventions" section to `DIRECTORY.md` that documents:
- The use of lowercase, plural directory names
- The canonical names for searching and sorting algorithms
- That older forms such as `Search/`, `searching/`, or `sort/` should be avoided

This keeps the project structure clear and consistent and resolves the original concern behind Issue 3.


<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [ ] All filenames are in PascalCase.
- [ ] All functions and variable names follow Java naming conventions.
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [ ] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`