### PR TITLE
style: include `UTAO_JUNIT_ASSERTION_ODDITIES_USE_ASSERT_NOT_NULL`

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -220,9 +220,6 @@
         <Bug pattern="UTAO_JUNIT_ASSERTION_ODDITIES_INEXACT_DOUBLE" />
     </Match>
     <Match>
-        <Bug pattern="UTAO_JUNIT_ASSERTION_ODDITIES_USE_ASSERT_NOT_NULL" />
-    </Match>
-    <Match>
         <Bug pattern="UTAO_JUNIT_ASSERTION_ODDITIES_IMPOSSIBLE_NULL" />
     </Match>
     <!-- find-sec-bugs -->

--- a/src/test/java/com/thealgorithms/datastructures/heaps/HeapElementTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/heaps/HeapElementTest.java
@@ -2,6 +2,7 @@ package com.thealgorithms.datastructures.heaps;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class HeapElementTest {
 
         assertEquals(element1, element2); // Same key and info
         assertNotEquals(element1, element3); // Different key
-        assertNotEquals(null, element1); // Check for null
+        assertNotNull(element1);
         assertNotEquals("String", element1); // Check for different type
     }
 

--- a/src/test/java/com/thealgorithms/maths/LinearDiophantineEquationsSolverTest.java
+++ b/src/test/java/com/thealgorithms/maths/LinearDiophantineEquationsSolverTest.java
@@ -176,7 +176,7 @@ class LinearDiophantineEquationsSolverTest {
         assertEquals(solution1, solution2);
         assertNotEquals(solution3, solution1);
         assertEquals(solution1, solution1);
-        assertNotEquals(null, solution1);
+        assertNotNull(solution1);
         assertNotEquals("string", solution1);
     }
 
@@ -217,7 +217,7 @@ class LinearDiophantineEquationsSolverTest {
         assertEquals(wrapper1, wrapper2);
         assertNotEquals(wrapper3, wrapper1);
         assertEquals(wrapper1, wrapper1);
-        assertNotEquals(null, wrapper1);
+        assertNotNull(wrapper1);
         assertNotEquals("string", wrapper1);
     }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->
Continuation of #5126 and #7222.
<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new algorithms include a corresponding test class that validates their functionality.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`
