### PR TITLE
Fix: NumberFormatException with non-ASCII Unicode digits in MyAtoi

### DIFF
--- a/src/main/java/com/thealgorithms/strings/MyAtoi.java
+++ b/src/main/java/com/thealgorithms/strings/MyAtoi.java
@@ -45,7 +45,9 @@ public final class MyAtoi {
         int number = 0;
         while (index < length) {
             char ch = s.charAt(index);
-            if (!Character.isDigit(ch)) {
+
+            // Accept only ASCII digits
+            if (ch < '0' || ch > '9') {
                 break;
             }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft,
- make sure that all of the CI checks pass,
- mark your PR as ready for review.
-->

Fixes #7205 (reported by @lionel-w2).

This PR resolves an issue in where non-ASCII Unicode digit characters (e.g., Arabic-Indic digit `١`) were incorrectly accepted by `Character.isDigit()` but parsed using ASCII arithmetic, leading to invalid parsing behavior.

The digit validation logic has been updated to accept **only ASCII digits (`'0'–'9'`)**, ensuring correct and predictable `atoi` behavior consistent with C/C++ semantics.

### Changes
- Replaced `Character.isDigit(ch)` with an explicit ASCII digit range check
- Ensures unsupported Unicode digits are treated as non-digit characters
- Prevents incorrect numeric accumulation

### Testing
- All existing tests pass
- Verified edge cases including Unicode digits, whitespace, signs, overflow, and empty input

![MyAtoi-Output](https://github.com/user-attachments/assets/26d4dea6-f7b3-4086-8e4e-837cc61839a4)
