### PR TITLE
style: resolve some of the `UTAO_JUNIT_ASSERTION_ODDITIES_USE_ASSERT_EQUALS` warnings

### DIFF
--- a/src/test/java/com/thealgorithms/backtracking/CombinationTest.java
+++ b/src/test/java/com/thealgorithms/backtracking/CombinationTest.java
@@ -28,16 +28,16 @@ public class CombinationTest {
     @Test
     void testLengthOne() {
         List<TreeSet<Integer>> result = Combination.combination(new Integer[] {1, 2}, 1);
-        assertTrue(result.get(0).iterator().next() == 1);
-        assertTrue(result.get(1).iterator().next() == 2);
+        assertEquals(1, result.get(0).iterator().next());
+        assertEquals(2, result.get(1).iterator().next());
     }
 
     @Test
     void testLengthTwo() {
         List<TreeSet<Integer>> result = Combination.combination(new Integer[] {1, 2}, 2);
         Integer[] arr = result.get(0).toArray(new Integer[2]);
-        assertTrue(arr[0] == 1);
-        assertTrue(arr[1] == 2);
+        assertEquals(1, arr[0]);
+        assertEquals(2, arr[1]);
     }
 
     @Test

--- a/src/test/java/com/thealgorithms/misc/ShuffleArrayTest.java
+++ b/src/test/java/com/thealgorithms/misc/ShuffleArrayTest.java
@@ -1,6 +1,7 @@
 package com.thealgorithms.misc;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -67,7 +68,7 @@ public class ShuffleArrayTest {
         ShuffleArray.shuffle(arr);
 
         // Check that the shuffled array contains the same elements
-        assertTrue(arr.length == 5);
+        assertEquals(5, arr.length);
         for (int i = 1; i <= 5; i++) {
             assertTrue(contains(arr, i));
         }

--- a/src/test/java/com/thealgorithms/others/PasswordGenTest.java
+++ b/src/test/java/com/thealgorithms/others/PasswordGenTest.java
@@ -17,7 +17,7 @@ public class PasswordGenTest {
     @Test
     public void generateOneCharacterPassword() {
         String tempPassword = PasswordGen.generatePassword(1, 2);
-        assertTrue(tempPassword.length() == 1);
+        assertEquals(1, tempPassword.length());
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank you for your contribution!
In order to reduce the number of notifications sent to the maintainers, please:
- create your PR as draft, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests,
- make sure that all of the CI checks pass,
- mark your PR as ready for review, cf. https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review
-->
Continuation of #5126 and #7222.

The remaining ones are false-positives (cf. mebigfatguy/fb-contrib#508) - it should be possible to remove `UTAO_JUNIT_ASSERTION_ODDITIES_USE_ASSERT_EQUALS` after fb-contril is updated to a newer version.

<!-- For completed items, change [ ] to [x] -->

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new algorithms include a corresponding test class that validates their functionality.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`
