### PR TITLE
fix: handle null and empty array in LinearSearch (issue #7340)

### DIFF
--- a/src/main/java/com/thealgorithms/searches/LinearSearch.java
+++ b/src/main/java/com/thealgorithms/searches/LinearSearch.java
@@ -41,10 +41,13 @@ public class LinearSearch implements SearchAlgorithm {
      *
      * @param array List to be searched
      * @param value Key being searched for
-     * @return Location of the key
+     * @return Location of the key, -1 if array is null or empty, or key not found
      */
     @Override
     public <T extends Comparable<T>> int find(T[] array, T value) {
+        if (array == null || array.length == 0) {
+            return -1;
+        }
         for (int i = 0; i < array.length; i++) {
             if (array[i].compareTo(value) == 0) {
                 return i;


### PR DESCRIPTION
## Summary

Fixes issue #7340 - LinearSearch does not explicitly handle null or empty arrays, which can cause unexpected NullPointerExceptions or incorrect behavior.

## Changes

- Added null check at the start of `find()` method
- Added empty array check (`array.length == 0`)
- Returns `-1` for null/empty input, consistent with BinarySearch behavior
- Updated Javadoc to document the return value for null/empty cases

## Behavior

| Input | Previous Behavior | New Behavior |
|-------|-------------------|--------------|
| `null` array | NPE | Returns `-1` |
| Empty array `[]` | Returns `-1` (loop never runs) | Returns `-1` (explicit) |
| Valid array, found | Returns index | Unchanged |
| Valid array, not found | Returns `-1` | Unchanged |

This is consistent with how `BinarySearch` handles null/empty input.

Fixes #7340