### PR TITLE
Fix: remove floating Javadoc comments causing compilation error

### DIFF
--- a/src/main/java/com/thealgorithms/conversions/AnyBaseToAnyBase.java
+++ b/src/main/java/com/thealgorithms/conversions/AnyBaseToAnyBase.java
@@ -1,10 +1,4 @@
-/**
- * [Brief description of what the algorithm does]
- * <p>
- * Time Complexity: O(n) [or appropriate complexity]
- * Space Complexity: O(n)
- * @author Reshma Kakkirala
- */
+
 package com.thealgorithms.conversions;
 
 import java.util.Arrays;

--- a/src/main/java/com/thealgorithms/searches/InterpolationSearch.java
+++ b/src/main/java/com/thealgorithms/searches/InterpolationSearch.java
@@ -1,14 +1,4 @@
-/**
- * Interpolation Search estimates the position of the target value
- * based on the distribution of values.
- *
- * Example:
- * Input: [10, 20, 30, 40], target = 30
- * Output: Index = 2
- *
- * Time Complexity: O(log log n) (average case)
- * Space Complexity: O(1)
- */
+
 package com.thealgorithms.searches;
 
 /**

--- a/src/main/java/com/thealgorithms/searches/LinearSearch.java
+++ b/src/main/java/com/thealgorithms/searches/LinearSearch.java
@@ -1,16 +1,4 @@
-/**
- * Performs Linear Search on an array.
- *
- * Linear search checks each element one by one until the target is found
- * or the array ends.
- *
- * Example:
- * Input: [2, 4, 6, 8], target = 6
- * Output: Index = 2
- *
- * Time Complexity: O(n)
- * Space Complexity: O(1)
- */
+
 package com.thealgorithms.searches;
 
 import com.thealgorithms.devutils.searches.SearchAlgorithm;


### PR DESCRIPTION
Fix: remove floating Javadoc comments causing -Werror compilation failure

Three files had Javadoc comments placed above the package statement, 
not attached to any declaration. With -Werror enabled, this caused 
the entire build to fail with "warnings found and -Werror specified".

Files fixed:
- conversions/AnyBaseToAnyBase.java
- searches/InterpolationSearch.java
- searches/LinearSearch.java

- [x] I have read CONTRIBUTING.md.
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [ ] All new algorithms include a corresponding test class that validates their functionality.
- [ ] All new code is formatted with clang-format