### PR TITLE
fix: add null input validation to AlternativeStringArrange.arrange()

### DIFF
--- a/src/main/java/com/thealgorithms/strings/AlternativeStringArrange.java
+++ b/src/main/java/com/thealgorithms/strings/AlternativeStringArrange.java
@@ -21,12 +21,19 @@ public final class AlternativeStringArrange {
 
     /**
      * Arranges two strings by alternating their characters.
+     * If one string is longer than the other, the remaining characters of the longer string
+     * are appended at the end of the result.
      *
-     * @param firstString  the first input string
-     * @param secondString the second input string
+     * @param firstString  the first input string, must not be {@code null}
+     * @param secondString the second input string, must not be {@code null}
      * @return a new string with characters from both strings arranged alternately
+     * @throws IllegalArgumentException if {@code firstString} or {@code secondString} is {@code null}
      */
     public static String arrange(String firstString, String secondString) {
+        if (firstString == null || secondString == null) {
+            throw new IllegalArgumentException("Input strings must not be null");
+        }
+
         StringBuilder result = new StringBuilder();
         int length1 = firstString.length();
         int length2 = secondString.length();

--- a/src/test/java/com/thealgorithms/strings/AlternativeStringArrangeTest.java
+++ b/src/test/java/com/thealgorithms/strings/AlternativeStringArrangeTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/com/thealgorithms/strings/AlternativeStringArrangeTest.java
+++ b/src/test/java/com/thealgorithms/strings/AlternativeStringArrangeTest.java
@@ -1,9 +1,12 @@
 package com.thealgorithms.strings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class AlternativeStringArrangeTest {
@@ -19,5 +22,16 @@ class AlternativeStringArrangeTest {
     @MethodSource("provideTestData")
     void arrangeTest(String input1, String input2, String expected) {
         assertEquals(expected, AlternativeStringArrange.arrange(input1, input2));
+    }
+
+    @ParameterizedTest(name = "null input ({0}, {1}) should throw IllegalArgumentException")
+    @MethodSource("provideNullInputs")
+    void arrangeThrowsOnNullInput(String input1, String input2) {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> AlternativeStringArrange.arrange(input1, input2));
+        assertEquals("Input strings must not be null", ex.getMessage());
+    }
+
+    private static Stream<Arguments> provideNullInputs() {
+        return Stream.of(Arguments.of(null, "abc"), Arguments.of("abc", null), Arguments.of(null, null));
     }
 }


### PR DESCRIPTION
### What

Adds explicit null-input validation to `AlternativeStringArrange.arrange()`.

Previously, calling `arrange(null, "abc")` (or with the second argument null, or both null) threw a `NullPointerException` from inside the method with no useful message. After this change, it throws an `IllegalArgumentException` with the message `"Input strings must not be null"`, matching the fail-fast convention already used by other utility classes in this package (for example `HammingDistance.calculateHammingDistance`).

### Why

- **Clearer contract**: `@throws IllegalArgumentException` is now documented in the Javadoc, so callers know what to expect.
- **Better error message**: an `NPE` with no message is hard to debug. `"Input strings must not be null"` makes the cause obvious.
- **Consistency**: aligns with the pattern in `HammingDistance` and other string utilities in this package.
- **No behavior change for valid inputs**: all existing test cases continue to pass unchanged.

### Changes

1. `src/main/java/.../AlternativeStringArrange.java`
   - Added a null guard at the top of `arrange()` throwing `IllegalArgumentException`.
   - Updated the method Javadoc with `@throws` and a note that inputs must be non-null.

2. `src/test/java/.../AlternativeStringArrangeTest.java`
   - Added a parameterized test `arrangeThrowsOnNullInput` covering all three null combinations: `(null, "abc")`, `("abc", null)`, `(null, null)`.
   - Verifies both the exception type and the message.

### Testing

All existing parameterized cases still pass. Three new null-input cases now also pass.

### Checklist

- [x] My code follows the code style of this project.
- [x] My code does not cause any duplication.
- [x] All new and existing tests pass.
- [x] All new code is covered by unit tests.
- [x] No new warnings are generated.