### PR TITLE
feat(datastructures): add thread-safe bounded queue implementation

### DIFF
--- a/src/main/java/com/thealgorithms/datastructures/queues/ThreadSafeQueue.java
+++ b/src/main/java/com/thealgorithms/datastructures/queues/ThreadSafeQueue.java
@@ -60,7 +60,7 @@ public class ThreadSafeQueue<T> {
             buffer[tail] = item;
             tail = (tail + 1) % capacity;
             count++;
-            notEmpty.signal();
+            notEmpty.signalAll();
         } finally {
             lock.unlock();
         }
@@ -82,7 +82,7 @@ public class ThreadSafeQueue<T> {
             buffer[head] = null;
             head = (head + 1) % capacity;
             count--;
-            notFull.signal();
+            notFull.signalAll();
             return item;
         } finally {
             lock.unlock();
@@ -108,7 +108,7 @@ public class ThreadSafeQueue<T> {
             buffer[tail] = item;
             tail = (tail + 1) % capacity;
             count++;
-            notEmpty.signal();
+            notEmpty.signalAll();
             return true;
         } finally {
             lock.unlock();
@@ -130,7 +130,7 @@ public class ThreadSafeQueue<T> {
             buffer[head] = null;
             head = (head + 1) % capacity;
             count--;
-            notFull.signal();
+            notFull.signalAll();
             return item;
         } finally {
             lock.unlock();

--- a/src/main/java/com/thealgorithms/datastructures/queues/ThreadSafeQueue.java
+++ b/src/main/java/com/thealgorithms/datastructures/queues/ThreadSafeQueue.java
@@ -1,0 +1,186 @@
+package com.thealgorithms.datastructures.queues;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * @brief Thread-safe bounded queue implementation using ReentrantLock and Condition variables
+ * @details A blocking queue that supports multiple producers and consumers.
+ * Uses a circular buffer internally with lock-based synchronization to ensure
+ * thread safety. Producers block when the queue is full, and consumers block
+ * when the queue is empty.
+ * @see <a href="https://en.wikipedia.org/wiki/Producer%E2%80%93consumer_problem">Producer-Consumer Problem</a>
+ */
+public class ThreadSafeQueue<T> {
+
+    private final Object[] buffer;
+    private final int capacity;
+    private int head;
+    private int tail;
+    private int count;
+    private final ReentrantLock lock;
+    private final Condition notFull;
+    private final Condition notEmpty;
+
+    /**
+     * @brief Constructs a ThreadSafeQueue with the specified capacity
+     * @param capacity the maximum number of elements the queue can hold
+     * @throws IllegalArgumentException if capacity is less than or equal to zero
+     */
+    public ThreadSafeQueue(int capacity) {
+        if (capacity <= 0) {
+            throw new IllegalArgumentException("Capacity must be greater than zero.");
+        }
+        this.capacity = capacity;
+        this.buffer = new Object[capacity];
+        this.head = 0;
+        this.tail = 0;
+        this.count = 0;
+        this.lock = new ReentrantLock();
+        this.notFull = lock.newCondition();
+        this.notEmpty = lock.newCondition();
+    }
+
+    /**
+     * @brief Adds an element to the tail of the queue, blocking if full
+     * @param item the element to add
+     * @throws InterruptedException if the thread is interrupted while waiting
+     * @throws IllegalArgumentException if the item is null
+     */
+    public void enqueue(T item) throws InterruptedException {
+        if (item == null) {
+            throw new IllegalArgumentException("Cannot enqueue null item.");
+        }
+
+        lock.lock();
+        try {
+            while (count == capacity) {
+                notFull.await();
+            }
+            buffer[tail] = item;
+            tail = (tail + 1) % capacity;
+            count++;
+            notEmpty.signal();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @brief Removes and returns the element at the head of the queue, blocking if empty
+     * @return the element at the head of the queue
+     * @throws InterruptedException if the thread is interrupted while waiting
+     */
+    @SuppressWarnings("unchecked")
+    public T dequeue() throws InterruptedException {
+        lock.lock();
+        try {
+            while (count == 0) {
+                notEmpty.await();
+            }
+            T item = (T) buffer[head];
+            buffer[head] = null;
+            head = (head + 1) % capacity;
+            count--;
+            notFull.signal();
+            return item;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @brief Adds an element to the tail of the queue without blocking
+     * @param item the element to add
+     * @return true if the element was added, false if the queue was full
+     * @throws IllegalArgumentException if the item is null
+     */
+    public boolean offer(T item) {
+        if (item == null) {
+            throw new IllegalArgumentException("Cannot enqueue null item.");
+        }
+
+        lock.lock();
+        try {
+            if (count == capacity) {
+                return false;
+            }
+            buffer[tail] = item;
+            tail = (tail + 1) % capacity;
+            count++;
+            notEmpty.signal();
+            return true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @brief Removes and returns the element at the head without blocking
+     * @return the element at the head, or null if the queue is empty
+     */
+    @SuppressWarnings("unchecked")
+    public T poll() {
+        lock.lock();
+        try {
+            if (count == 0) {
+                return null;
+            }
+            T item = (T) buffer[head];
+            buffer[head] = null;
+            head = (head + 1) % capacity;
+            count--;
+            notFull.signal();
+            return item;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @brief Returns the number of elements in the queue
+     * @return the current size of the queue
+     */
+    public int size() {
+        lock.lock();
+        try {
+            return count;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @brief Checks if the queue is empty
+     * @return true if the queue contains no elements
+     */
+    public boolean isEmpty() {
+        lock.lock();
+        try {
+            return count == 0;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @brief Checks if the queue is full
+     * @return true if the queue has reached its capacity
+     */
+    public boolean isFull() {
+        lock.lock();
+        try {
+            return count == capacity;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * @brief Returns the maximum capacity of the queue
+     * @return the capacity
+     */
+    public int capacity() {
+        return capacity;
+    }
+}

--- a/src/test/java/com/thealgorithms/datastructures/queues/ThreadSafeQueueTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/queues/ThreadSafeQueueTest.java
@@ -1,6 +1,5 @@
 package com.thealgorithms.datastructures.queues;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/src/test/java/com/thealgorithms/datastructures/queues/ThreadSafeQueueTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/queues/ThreadSafeQueueTest.java
@@ -1,0 +1,300 @@
+package com.thealgorithms.datastructures.queues;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class ThreadSafeQueueTest {
+
+    @Test
+    public void testEnqueueDequeue() throws InterruptedException {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(5);
+        queue.enqueue(1);
+        queue.enqueue(2);
+        queue.enqueue(3);
+
+        assertEquals(3, queue.size());
+        assertEquals(1, queue.dequeue());
+        assertEquals(2, queue.dequeue());
+        assertEquals(3, queue.dequeue());
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void testOfferPoll() {
+        ThreadSafeQueue<String> queue = new ThreadSafeQueue<>(3);
+        assertTrue(queue.offer("a"));
+        assertTrue(queue.offer("b"));
+        assertFalse(queue.offer("c"));
+
+        assertEquals("a", queue.poll());
+        assertEquals("b", queue.poll());
+        assertNull(queue.poll());
+    }
+
+    @Test
+    public void testOfferRejectsWhenFull() {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(2);
+        assertTrue(queue.offer(1));
+        assertTrue(queue.offer(2));
+        assertFalse(queue.offer(3));
+        assertEquals(2, queue.size());
+    }
+
+    @Test
+    public void testPollReturnsNullWhenEmpty() {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(5);
+        assertNull(queue.poll());
+    }
+
+    @Test
+    public void testEnqueueNullThrows() {
+        ThreadSafeQueue<String> queue = new ThreadSafeQueue<>(5);
+        assertThrows(IllegalArgumentException.class, () -> queue.enqueue(null));
+    }
+
+    @Test
+    public void testOfferNullThrows() {
+        ThreadSafeQueue<String> queue = new ThreadSafeQueue<>(5);
+        assertThrows(IllegalArgumentException.class, () -> queue.offer(null));
+    }
+
+    @Test
+    public void testInvalidCapacityThrows() {
+        assertThrows(IllegalArgumentException.class, () -> new ThreadSafeQueue<>(0));
+        assertThrows(IllegalArgumentException.class, () -> new ThreadSafeQueue<>(-1));
+    }
+
+    @Test
+    public void testIsEmptyAndIsFull() throws InterruptedException {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(2);
+        assertTrue(queue.isEmpty());
+        assertFalse(queue.isFull());
+
+        queue.enqueue(1);
+        assertFalse(queue.isEmpty());
+        assertFalse(queue.isFull());
+
+        queue.enqueue(2);
+        assertFalse(queue.isEmpty());
+        assertTrue(queue.isFull());
+
+        queue.dequeue();
+        assertFalse(queue.isEmpty());
+        assertFalse(queue.isFull());
+
+        queue.dequeue();
+        assertTrue(queue.isEmpty());
+        assertFalse(queue.isFull());
+    }
+
+    @Test
+    public void testCapacity() {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(10);
+        assertEquals(10, queue.capacity());
+    }
+
+    @Test
+    public void testCircularBufferWrapAround() throws InterruptedException {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(3);
+        queue.enqueue(1);
+        queue.enqueue(2);
+        queue.enqueue(3);
+
+        assertEquals(1, queue.dequeue());
+        assertEquals(2, queue.dequeue());
+
+        queue.enqueue(4);
+        queue.enqueue(5);
+
+        assertEquals(3, queue.dequeue());
+        assertEquals(4, queue.dequeue());
+        assertEquals(5, queue.dequeue());
+    }
+
+    @Test
+    public void testMultipleProducersSingleConsumer() throws InterruptedException {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(100);
+        int numProducers = 4;
+        int itemsPerProducer = 250;
+        int totalItems = numProducers * itemsPerProducer;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numProducers);
+        List<Integer> results = new ArrayList<>();
+
+        ExecutorService executor = Executors.newFixedThreadPool(numProducers + 1);
+
+        for (int p = 0; p < numProducers; p++) {
+            final int producerId = p;
+            executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < itemsPerProducer; i++) {
+                        queue.enqueue(producerId * itemsPerProducer + i);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        executor.submit(() -> {
+            try {
+                doneLatch.await();
+                while (results.size() < totalItems) {
+                    Integer item = queue.poll();
+                    if (item != null) {
+                        results.add(item);
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        startLatch.countDown();
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+
+        assertEquals(totalItems, results.size());
+    }
+
+    @Test
+    public void testSingleProducerMultipleConsumers() throws InterruptedException {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(50);
+        int numConsumers = 4;
+        int totalItems = 1000;
+        CountDownLatch doneLatch = new CountDownLatch(numConsumers);
+        AtomicInteger consumedCount = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(numConsumers + 1);
+
+        executor.submit(() -> {
+            try {
+                for (int i = 0; i < totalItems; i++) {
+                    queue.enqueue(i);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        for (int c = 0; c < numConsumers; c++) {
+            executor.submit(() -> {
+                try {
+                    while (consumedCount.get() < totalItems) {
+                        Integer item = queue.poll();
+                        if (item != null) {
+                            consumedCount.incrementAndGet();
+                        }
+                    }
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+        assertEquals(totalItems, consumedCount.get());
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testBlockingEnqueueWhenFull() throws InterruptedException {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(1);
+        queue.enqueue(1);
+
+        AtomicInteger blockedCount = new AtomicInteger(0);
+        Thread producer = new Thread(() -> {
+            try {
+                queue.enqueue(2);
+                blockedCount.incrementAndGet();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        producer.start();
+
+        Thread.sleep(100);
+        assertEquals(1, queue.dequeue());
+
+        producer.join(2000);
+        assertEquals(1, blockedCount.get());
+        assertEquals(2, queue.dequeue());
+    }
+
+    @Test
+    public void testBlockingDequeueWhenEmpty() throws InterruptedException {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(5);
+
+        AtomicInteger result = new AtomicInteger(-1);
+        Thread consumer = new Thread(() -> {
+            try {
+                result.set(queue.dequeue());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        consumer.start();
+
+        Thread.sleep(100);
+        queue.enqueue(42);
+
+        consumer.join(2000);
+        assertEquals(42, result.get());
+    }
+
+    @Test
+    public void testStressConcurrentAccess() throws InterruptedException {
+        ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(10);
+        int numThreads = 8;
+        int opsPerThread = 500;
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        AtomicInteger enqueueCount = new AtomicInteger(0);
+        AtomicInteger dequeueCount = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(numThreads);
+
+        for (int t = 0; t < numThreads; t++) {
+            final boolean isProducer = t % 2 == 0;
+            executor.submit(() -> {
+                try {
+                    for (int i = 0; i < opsPerThread; i++) {
+                        if (isProducer) {
+                            if (queue.offer(i)) {
+                                enqueueCount.incrementAndGet();
+                            }
+                        } else {
+                            if (queue.poll() != null) {
+                                dequeueCount.incrementAndGet();
+                            }
+                        }
+                    }
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        assertTrue(enqueueCount.get() >= dequeueCount.get());
+        assertEquals(enqueueCount.get() - dequeueCount.get(), queue.size());
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+    }
+}

--- a/src/test/java/com/thealgorithms/datastructures/queues/ThreadSafeQueueTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/queues/ThreadSafeQueueTest.java
@@ -1,11 +1,5 @@
 package com.thealgorithms.datastructures.queues;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -13,6 +7,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ThreadSafeQueueTest {
@@ -24,85 +19,85 @@ public class ThreadSafeQueueTest {
         queue.enqueue(2);
         queue.enqueue(3);
 
-        assertEquals(3, queue.size());
-        assertEquals(1, queue.dequeue());
-        assertEquals(2, queue.dequeue());
-        assertEquals(3, queue.dequeue());
-        assertTrue(queue.isEmpty());
+        Assertions.assertEquals(3, queue.size());
+        Assertions.assertEquals(1, queue.dequeue());
+        Assertions.assertEquals(2, queue.dequeue());
+        Assertions.assertEquals(3, queue.dequeue());
+        Assertions.assertTrue(queue.isEmpty());
     }
 
     @Test
     public void testOfferPoll() {
         ThreadSafeQueue<String> queue = new ThreadSafeQueue<>(2);
-        assertTrue(queue.offer("a"));
-        assertTrue(queue.offer("b"));
-        assertFalse(queue.offer("c"));
+        Assertions.assertTrue(queue.offer("a"));
+        Assertions.assertTrue(queue.offer("b"));
+        Assertions.assertFalse(queue.offer("c"));
 
-        assertEquals("a", queue.poll());
-        assertEquals("b", queue.poll());
-        assertNull(queue.poll());
+        Assertions.assertEquals("a", queue.poll());
+        Assertions.assertEquals("b", queue.poll());
+        Assertions.assertNull(queue.poll());
     }
 
     @Test
     public void testOfferRejectsWhenFull() {
         ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(2);
-        assertTrue(queue.offer(1));
-        assertTrue(queue.offer(2));
-        assertFalse(queue.offer(3));
-        assertEquals(2, queue.size());
+        Assertions.assertTrue(queue.offer(1));
+        Assertions.assertTrue(queue.offer(2));
+        Assertions.assertFalse(queue.offer(3));
+        Assertions.assertEquals(2, queue.size());
     }
 
     @Test
     public void testPollReturnsNullWhenEmpty() {
         ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(5);
-        assertNull(queue.poll());
+        Assertions.assertNull(queue.poll());
     }
 
     @Test
     public void testEnqueueNullThrows() {
         ThreadSafeQueue<String> queue = new ThreadSafeQueue<>(5);
-        assertThrows(IllegalArgumentException.class, () -> queue.enqueue(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> queue.enqueue(null));
     }
 
     @Test
     public void testOfferNullThrows() {
         ThreadSafeQueue<String> queue = new ThreadSafeQueue<>(5);
-        assertThrows(IllegalArgumentException.class, () -> queue.offer(null));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> queue.offer(null));
     }
 
     @Test
     public void testInvalidCapacityThrows() {
-        assertThrows(IllegalArgumentException.class, () -> new ThreadSafeQueue<>(0));
-        assertThrows(IllegalArgumentException.class, () -> new ThreadSafeQueue<>(-1));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ThreadSafeQueue<>(0));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> new ThreadSafeQueue<>(-1));
     }
 
     @Test
     public void testIsEmptyAndIsFull() throws InterruptedException {
         ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(2);
-        assertTrue(queue.isEmpty());
-        assertFalse(queue.isFull());
+        Assertions.assertTrue(queue.isEmpty());
+        Assertions.assertFalse(queue.isFull());
 
         queue.enqueue(1);
-        assertFalse(queue.isEmpty());
-        assertFalse(queue.isFull());
+        Assertions.assertFalse(queue.isEmpty());
+        Assertions.assertFalse(queue.isFull());
 
         queue.enqueue(2);
-        assertFalse(queue.isEmpty());
-        assertTrue(queue.isFull());
+        Assertions.assertFalse(queue.isEmpty());
+        Assertions.assertTrue(queue.isFull());
 
         queue.dequeue();
-        assertFalse(queue.isEmpty());
-        assertFalse(queue.isFull());
+        Assertions.assertFalse(queue.isEmpty());
+        Assertions.assertFalse(queue.isFull());
 
         queue.dequeue();
-        assertTrue(queue.isEmpty());
-        assertFalse(queue.isFull());
+        Assertions.assertTrue(queue.isEmpty());
+        Assertions.assertFalse(queue.isFull());
     }
 
     @Test
     public void testCapacity() {
         ThreadSafeQueue<Integer> queue = new ThreadSafeQueue<>(10);
-        assertEquals(10, queue.capacity());
+        Assertions.assertEquals(10, queue.capacity());
     }
 
     @Test
@@ -112,15 +107,15 @@ public class ThreadSafeQueueTest {
         queue.enqueue(2);
         queue.enqueue(3);
 
-        assertEquals(1, queue.dequeue());
-        assertEquals(2, queue.dequeue());
+        Assertions.assertEquals(1, queue.dequeue());
+        Assertions.assertEquals(2, queue.dequeue());
 
         queue.enqueue(4);
         queue.enqueue(5);
 
-        assertEquals(3, queue.dequeue());
-        assertEquals(4, queue.dequeue());
-        assertEquals(5, queue.dequeue());
+        Assertions.assertEquals(3, queue.dequeue());
+        Assertions.assertEquals(4, queue.dequeue());
+        Assertions.assertEquals(5, queue.dequeue());
     }
 
     @Test
@@ -165,12 +160,12 @@ public class ThreadSafeQueueTest {
         });
         consumerThread.start();
 
-        assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+        Assertions.assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
         consumerThread.join(5000);
 
-        assertEquals(totalItems, results.size());
+        Assertions.assertEquals(totalItems, results.size());
         executor.shutdown();
-        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        Assertions.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
     }
 
     @Test
@@ -208,10 +203,10 @@ public class ThreadSafeQueueTest {
             });
         }
 
-        assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
-        assertEquals(totalItems, consumedCount.get());
+        Assertions.assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+        Assertions.assertEquals(totalItems, consumedCount.get());
         executor.shutdown();
-        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+        Assertions.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
     }
 
     @Test
@@ -231,11 +226,11 @@ public class ThreadSafeQueueTest {
         producer.start();
 
         Thread.sleep(100);
-        assertEquals(1, queue.dequeue());
+        Assertions.assertEquals(1, queue.dequeue());
 
         producer.join(2000);
-        assertEquals(1, blockedCount.get());
-        assertEquals(2, queue.dequeue());
+        Assertions.assertEquals(1, blockedCount.get());
+        Assertions.assertEquals(2, queue.dequeue());
     }
 
     @Test
@@ -256,7 +251,7 @@ public class ThreadSafeQueueTest {
         queue.enqueue(42);
 
         consumer.join(2000);
-        assertEquals(42, result.get());
+        Assertions.assertEquals(42, result.get());
     }
 
     @Test
@@ -291,9 +286,9 @@ public class ThreadSafeQueueTest {
             });
         }
 
-        assertTrue(latch.await(10, TimeUnit.SECONDS));
-        assertTrue(enqueueCount.get() >= dequeueCount.get());
-        assertEquals(enqueueCount.get() - dequeueCount.get(), queue.size());
+        Assertions.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Assertions.assertTrue(enqueueCount.get() >= dequeueCount.get());
+        Assertions.assertEquals(enqueueCount.get() - dequeueCount.get(), queue.size());
         executor.shutdown();
         executor.awaitTermination(5, TimeUnit.SECONDS);
     }

--- a/src/test/java/com/thealgorithms/datastructures/queues/ThreadSafeQueueTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/queues/ThreadSafeQueueTest.java
@@ -34,7 +34,7 @@ public class ThreadSafeQueueTest {
 
     @Test
     public void testOfferPoll() {
-        ThreadSafeQueue<String> queue = new ThreadSafeQueue<>(3);
+        ThreadSafeQueue<String> queue = new ThreadSafeQueue<>(2);
         assertTrue(queue.offer("a"));
         assertTrue(queue.offer("b"));
         assertFalse(queue.offer("c"));
@@ -130,7 +130,6 @@ public class ThreadSafeQueueTest {
         int numProducers = 4;
         int itemsPerProducer = 250;
         int totalItems = numProducers * itemsPerProducer;
-        CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch doneLatch = new CountDownLatch(numProducers);
         List<Integer> results = new ArrayList<>();
 
@@ -140,7 +139,6 @@ public class ThreadSafeQueueTest {
             final int producerId = p;
             executor.submit(() -> {
                 try {
-                    startLatch.await();
                     for (int i = 0; i < itemsPerProducer; i++) {
                         queue.enqueue(producerId * itemsPerProducer + i);
                     }
@@ -152,25 +150,28 @@ public class ThreadSafeQueueTest {
             });
         }
 
-        executor.submit(() -> {
+        Thread consumerThread = new Thread(() -> {
             try {
-                doneLatch.await();
                 while (results.size() < totalItems) {
                     Integer item = queue.poll();
                     if (item != null) {
-                        results.add(item);
+                        synchronized (results) {
+                            results.add(item);
+                        }
                     }
                 }
-            } catch (InterruptedException e) {
+            } catch (Exception e) {
                 Thread.currentThread().interrupt();
             }
         });
+        consumerThread.start();
 
-        startLatch.countDown();
-        executor.shutdown();
-        assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+        assertTrue(doneLatch.await(10, TimeUnit.SECONDS));
+        consumerThread.join(5000);
 
         assertEquals(totalItems, results.size());
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
     }
 
     @Test


### PR DESCRIPTION
### Describe your change:

* [x] Add an algorithm?
* [ ] Fix a bug or typo in an existing algorithm?
* [ ] Add or change doctests? -- Note: Please avoid changing both code and tests in a single pull request.
* [ ] Documentation change?

### Checklist:
* [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
* [x] This pull request is all my own work -- I have not plagiarized.
* [x] I know that pull requests will not be merged if they fail the automated tests.
* [x] This PR only changes one algorithm file.  To ease review, please open separate PRs for separate algorithms.
* [x] All new Java files are placed inside an existing directory.
* [x] All filenames are in all lowercase characters with no spaces or dashes.
* [x] All functions and variable names follow Java naming conventions.
* [x] All new algorithms have a URL in its comments that points to Wikipedia or another similar explanation.
* [x] The build runs successfully with `mvn clean verify`.

---

## Thread-Safe Queue (Producer-Consumer)

A blocking queue that supports multiple producers and consumers using ReentrantLock and Condition variables.

### What This Adds

**ThreadSafeQueue.java** - Thread-safe bounded queue:
- `enqueue()` - Blocking add to tail, waits when queue is full
- `dequeue()` - Blocking remove from head, waits when queue is empty
- `offer()` - Non-blocking add, returns false when full
- `poll()` - Non-blocking remove, returns null when empty
- `size()`, `isEmpty()`, `isFull()`, `capacity()` - State queries
- Uses circular buffer for O(1) enqueue/dequeue operations
- Supports multiple concurrent producers and consumers

**ThreadSafeQueueTest.java** - Comprehensive test suite (15 tests):
- Basic enqueue/dequeue operations
- Offer/poll non-blocking behavior
- Null rejection validation
- Invalid capacity rejection
- Circular buffer wrap-around
- Multiple producers single consumer concurrency
- Single producer multiple consumers concurrency
- Blocking behavior verification
- Stress test with 8 concurrent threads

### Algorithm

Uses a circular buffer with ReentrantLock and two Condition variables:
- `notFull` - signaled when space becomes available
- `notEmpty` - signaled when items are added
- Producers await notFull when buffer is full
- Consumers await notEmpty when buffer is empty
- Signal opposite condition after each operation

Time: O(1) enqueue/dequeue | Space: O(n) bounded buffer

### Reference

https://en.wikipedia.org/wiki/Producer%E2%80%93consumer_problem