### PR TITLE
Fix division by zero in interpolation search

### DIFF
--- a/src/main/java/com/thealgorithms/searches/InterpolationSearch.java
+++ b/src/main/java/com/thealgorithms/searches/InterpolationSearch.java
@@ -36,9 +36,12 @@ class InterpolationSearch {
         // Since array is sorted, an element present
         // in array must be in range defined by corner
         while (start <= end && key >= array[start] && key <= array[end]) {
+            if (array[start] == array[end]) {
+                return start;
+            }
             // Probing the position with keeping
             // uniform distribution in mind.
-            int pos = start + (((end - start) / (array[end] - array[start])) * (key - array[start]));
+            int pos = start + (int) (((long) (end - start) * (key - array[start])) / ((long) array[end] - array[start]));
 
             // Condition of target found
             if (array[pos] == key) {

--- a/src/test/java/com/thealgorithms/searches/InterpolationSearchTest.java
+++ b/src/test/java/com/thealgorithms/searches/InterpolationSearchTest.java
@@ -94,8 +94,8 @@ class InterpolationSearchTest {
     @Test
     void testInterpolationSearchDivisionByZeroEdgeCases() {
         InterpolationSearch interpolationSearch = new InterpolationSearch();
-        assertEquals(3, interpolationSearch.find(new int[]{0, 0, 0, 2}, 2));
-        assertEquals(0, interpolationSearch.find(new int[]{2, 2, 2, 2}, 2));
-        assertEquals(3, interpolationSearch.find(new int[]{0, 1, 2, 4}, 4));
+        assertEquals(3, interpolationSearch.find(new int[] {0, 0, 0, 2}, 2));
+        assertEquals(0, interpolationSearch.find(new int[] {2, 2, 2, 2}, 2));
+        assertEquals(3, interpolationSearch.find(new int[] {0, 1, 2, 4}, 4));
     }
 }

--- a/src/test/java/com/thealgorithms/searches/InterpolationSearchTest.java
+++ b/src/test/java/com/thealgorithms/searches/InterpolationSearchTest.java
@@ -87,4 +87,15 @@ class InterpolationSearchTest {
         int key = 21; // Present in the array
         assertEquals(6, interpolationSearch.find(array, key), "The index of the found element should be 6.");
     }
+
+    /**
+     * Test for interpolation search with specific sorted arrays that previously caused division by zero.
+     */
+    @Test
+    void testInterpolationSearchDivisionByZeroEdgeCases() {
+        InterpolationSearch interpolationSearch = new InterpolationSearch();
+        assertEquals(3, interpolationSearch.find(new int[]{0, 0, 0, 2}, 2));
+        assertEquals(0, interpolationSearch.find(new int[]{2, 2, 2, 2}, 2));
+        assertEquals(3, interpolationSearch.find(new int[]{0, 1, 2, 4}, 4));
+    }
 }


### PR DESCRIPTION
### Description
This PR fixes a `java.lang.ArithmeticException: / by zero` in `InterpolationSearch.find(...)` and resolves an issue with the interpolation calculation logic.

### Related Issue
Fixes #7466

### Changes Made
1. **Division by Zero Prevention:** Added a check `if (array[start] == array[end])` inside the search loop. If the bounds are equal and the search key lies within them, it returns `start` directly. This avoids division by zero when calculating the probing position.
2. **Interpolation Formula Fix:** Modified the probing index calculation to cast the numerator to `long` before performing division: 
   `int pos = start + (int) (((long) (end - start) * (key - array[start])) / ((long) array[end] - array[start]));`
   This prevents truncation from integer division (which was causing the algorithm to fallback to a linear search in most cases) and prevents integer overflow.
3. **Tests Added:** Added `testInterpolationSearchDivisionByZeroEdgeCases` in `InterpolationSearchTest.java` covering the cases described in the issue:
   - `[0, 0, 0, 2], 2 -> 3`
   - `[2, 2, 2, 2], 2 -> 0`
   - `[0, 1, 2, 4], 4 -> 3`

### Checklist
- [x] Code compiles successfully.
- [x] Unit tests added and passed.
- [x] Followed repository code style.
