### PR TITLE
chore: move HeavyLightDecomposition to datastructures/trees

### DIFF
--- a/src/main/java/com/thealgorithms/datastructures/trees/HeavyLightDecomposition.java
+++ b/src/main/java/com/thealgorithms/datastructures/trees/HeavyLightDecomposition.java
@@ -1,4 +1,4 @@
-package com.thealgorithms.tree;
+package com.thealgorithms.datastructures.trees;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/com/thealgorithms/datastructures/trees/HeavyLightDecompositionTest.java
+++ b/src/test/java/com/thealgorithms/datastructures/trees/HeavyLightDecompositionTest.java
@@ -1,4 +1,4 @@
-package com.thealgorithms.tree;
+package com.thealgorithms.datastructures.trees;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
### Description
This PR resolves a structural inconsistency where a single file, `HeavyLightDecomposition.java`, resided in a top-level `tree/` package, while all other tree algorithms are placed under `datastructures/trees/`.

### Related Issue
Fixes #7453

### Changes Made
- Moved `HeavyLightDecomposition.java` to `src/main/java/com/thealgorithms/datastructures/trees/`
- Moved `HeavyLightDecompositionTest.java` to `src/test/java/com/thealgorithms/datastructures/trees/`
- Updated package declarations to `com.thealgorithms.datastructures.trees` in both files
- Deleted the now-empty `tree/` directories

### Checklist
- [x] Code compiles successfully.
- [x] Unit tests passed.
- [x] Followed repository code style rules.
