### PR TITLE
fix: validate that all  characters after first padding character in Base64 decode

### DIFF
--- a/src/main/java/com/thealgorithms/conversions/Base64.java
+++ b/src/main/java/com/thealgorithms/conversions/Base64.java
@@ -119,8 +119,15 @@ public final class Base64 {
 
         // Validate padding: '=' can only appear at the end (last 1 or 2 chars)
         int firstPadding = input.indexOf('=');
-        if (firstPadding != -1 && firstPadding < input.length() - 2) {
-            throw new IllegalArgumentException("Padding '=' can only appear at the end (last 1 or 2 characters)");
+        if (firstPadding != -1) {
+            if (firstPadding < input.length() - 2) {
+                throw new IllegalArgumentException("Padding '=' can only appear at the end (last 1 or 2 characters)");
+            }
+            for (int i = firstPadding; i < input.length(); i++) {
+                if (input.charAt(i) != '=') {
+                    throw new IllegalArgumentException("A padding '=' must not be followed by a non-padding character");
+                }
+            }
         }
 
         List<Byte> result = new ArrayList<>();

--- a/src/test/java/com/thealgorithms/conversions/Base64Test.java
+++ b/src/test/java/com/thealgorithms/conversions/Base64Test.java
@@ -127,6 +127,9 @@ class Base64Test {
         assertThrows(IllegalArgumentException.class, () -> Base64.decode("Q=QQ"));
         assertThrows(IllegalArgumentException.class, () -> Base64.decode("Q=Q="));
         assertThrows(IllegalArgumentException.class, () -> Base64.decode("=QQQ"));
+        assertThrows(IllegalArgumentException.class, () -> Base64.decode("QQ=Q"));
+        assertThrows(IllegalArgumentException.class, () -> Base64.decode("AB=C"));
+        assertThrows(IllegalArgumentException.class, () -> Base64.decode("AB=A"));
     }
 
     @Test


### PR DESCRIPTION
### Description
Fixes a bug where `Base64.decode` accepted malformed inputs with data characters appearing after a padding character `=` (e.g. "QQ=Q"). 

### Related Issue
Fixes #7482

### Changes
- Updated `Base64.decode` to assert that all characters starting from the first `=` character to the end of the input string are also `=`.
- Added unit test cases in `Base64Test.java` to prevent regression.
