### PR TITLE
docs: cross-reference nth-fibonacci implementations via javadocs

### DIFF
--- a/src/main/java/com/thealgorithms/dynamicprogramming/Fibonacci.java
+++ b/src/main/java/com/thealgorithms/dynamicprogramming/Fibonacci.java
@@ -1,12 +1,10 @@
 package com.thealgorithms.dynamicprogramming;
-
 import java.util.HashMap;
 import java.util.Map;
-
 /**
  * Collection of Dynamic Programming techniques to solve for the n-th Fibonacci number.
  * <p>
- * This file showcases Top-Down Memoization ({@code fibMemo}), Bottom-Up Tabulation ({@code fibBotUp}), 
+ * This file showcases Top-Down Memoization ({@code fibMemo}), Bottom-Up Tabulation ({@code fibBotUp}),
  * and Space-Optimized Iteration ({@code fibOptimized}).
  * <p>
  * For alternative structural paradigms, mathematical formulas, or verification steps, see:

--- a/src/main/java/com/thealgorithms/dynamicprogramming/Fibonacci.java
+++ b/src/main/java/com/thealgorithms/dynamicprogramming/Fibonacci.java
@@ -4,7 +4,21 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @author Varun Upadhyay (https://github.com/varunu28)
+ * Collection of Dynamic Programming techniques to solve for the n-th Fibonacci number.
+ * <p>
+ * This file showcases Top-Down Memoization ({@code fibMemo}), Bottom-Up Tabulation ({@code fibBotUp}), 
+ * and Space-Optimized Iteration ({@code fibOptimized}).
+ * <p>
+ * For alternative structural paradigms, mathematical formulas, or verification steps, see:
+ * <ul>
+ * <li>{@link com.thealgorithms.maths.FibonacciLoop} - Standard Iterative (Loop) approach</li>
+ * <li>{@link com.thealgorithms.recursion.FibonacciSeries} - Naive Recursive approach</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciJavaStreams} - Functional approach using Java Streams</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberGoldenRation} - Closed-form expression using Binet's formula</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberCheck} - Utility to check if a given number is a Fibonacci number</li>
+ * <li>{@link com.thealgorithms.matrix.matrixexponentiation.Fibonacci} - O(log n) Matrix Exponentiation approach</li>
+ * </ul>
+ * * @author Varun Upadhyay (https://github.com/varunu28)
  */
 public final class Fibonacci {
     private Fibonacci() {

--- a/src/main/java/com/thealgorithms/maths/FibonacciJavaStreams.java
+++ b/src/main/java/com/thealgorithms/maths/FibonacciJavaStreams.java
@@ -6,9 +6,23 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * @author: caos321
- * @date: 14 October 2021 (Thursday)
+ * Calculates Fibonacci numbers using a functional programming paradigm with Java Streams.
+ * <p>
+ * This specific implementation uses {@link java.util.stream.Stream#iterate} and reductions to generate terms.
+ * <p>
+ * For alternative approaches to compute or verify Fibonacci numbers, see:
+ * <ul>
+ * <li>{@link com.thealgorithms.maths.FibonacciLoop} - Standard Iterative (Loop) approach</li>
+ * <li>{@link com.thealgorithms.recursion.FibonacciSeries} - Naive Recursive approach</li>
+ * <li>{@link com.thealgorithms.dynamicprogramming.Fibonacci} - Dynamic Programming approaches (Memoization, Bottom-Up, Optimized)</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberGoldenRation} - Closed-form expression using Binet's formula</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberCheck} - Utility to check if a given number is a Fibonacci number</li>
+ * <li>{@link com.thealgorithms.matrix.matrixexponentiation.Fibonacci} - O(log n) Matrix Exponentiation approach</li>
+ * </ul>
+ * * @author caos321
+ * @date 14 October 2021 (Thursday)
  */
+
 public final class FibonacciJavaStreams {
     private FibonacciJavaStreams() {
     }

--- a/src/main/java/com/thealgorithms/maths/FibonacciLoop.java
+++ b/src/main/java/com/thealgorithms/maths/FibonacciLoop.java
@@ -1,11 +1,9 @@
 package com.thealgorithms.maths;
-
 import java.math.BigInteger;
-
 /**
  * This class provides methods for calculating Fibonacci numbers using BigInteger for large values of 'n'.
  * <p>
- * This specific implementation uses an <b>Iterative approach (Loop)</b> with {@code O(n)} time complexity 
+ * This specific implementation uses an <b>Iterative approach (Loop)</b> with {@code O(n)} time complexity
  * and {@code O(1)} space complexity.
  * <p>
  * For alternative approaches to compute or verify Fibonacci numbers, see:

--- a/src/main/java/com/thealgorithms/maths/FibonacciLoop.java
+++ b/src/main/java/com/thealgorithms/maths/FibonacciLoop.java
@@ -4,6 +4,19 @@ import java.math.BigInteger;
 
 /**
  * This class provides methods for calculating Fibonacci numbers using BigInteger for large values of 'n'.
+ * <p>
+ * This specific implementation uses an <b>Iterative approach (Loop)</b> with {@code O(n)} time complexity 
+ * and {@code O(1)} space complexity.
+ * <p>
+ * For alternative approaches to compute or verify Fibonacci numbers, see:
+ * <ul>
+ * <li>{@link com.thealgorithms.recursion.FibonacciSeries} - Naive Recursive approach</li>
+ * <li>{@link com.thealgorithms.dynamicprogramming.Fibonacci} - Dynamic Programming approaches (Memoization, Bottom-Up, Optimized)</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciJavaStreams} - Functional approach using Java Streams</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberGoldenRation} - Closed-form expression using Binet's formula</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberCheck} - Utility to check if a given number is a Fibonacci number</li>
+ * <li>{@link com.thealgorithms.matrix.matrixexponentiation.Fibonacci} - O(log n) Matrix Exponentiation approach</li>
+ * </ul>
  */
 public final class FibonacciLoop {
 

--- a/src/main/java/com/thealgorithms/maths/FibonacciNumberCheck.java
+++ b/src/main/java/com/thealgorithms/maths/FibonacciNumberCheck.java
@@ -4,6 +4,18 @@ package com.thealgorithms.maths;
  * Fibonacci: 0 1 1 2 3 5 8 13 21 ...
  * This code checks Fibonacci Numbers up to 45th number.
  * Other checks fail because of 'long'-type overflow.
+ * <p>
+ * This class serves as a <b>verification utility</b> rather than a generation algorithm.
+ * <p>
+ * For approaches that actively compute the n-th Fibonacci number, see:
+ * <ul>
+ * <li>{@link com.thealgorithms.maths.FibonacciLoop} - Standard Iterative (Loop) approach</li>
+ * <li>{@link com.thealgorithms.recursion.FibonacciSeries} - Naive Recursive approach</li>
+ * <li>{@link com.thealgorithms.dynamicprogramming.Fibonacci} - Dynamic Programming approaches (Memoization, Bottom-Up, Optimized)</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciJavaStreams} - Functional approach using Java Streams</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberGoldenRation} - Closed-form expression using Binet's formula</li>
+ * <li>{@link com.thealgorithms.matrix.matrixexponentiation.Fibonacci} - O(log n) Matrix Exponentiation approach</li>
+ * </ul>
  */
 public final class FibonacciNumberCheck {
     private FibonacciNumberCheck() {

--- a/src/main/java/com/thealgorithms/maths/FibonacciNumberGoldenRation.java
+++ b/src/main/java/com/thealgorithms/maths/FibonacciNumberGoldenRation.java
@@ -3,6 +3,18 @@ package com.thealgorithms.maths;
 /**
  * This class provides methods for calculating Fibonacci numbers using Binet's formula.
  * Binet's formula is based on the golden ratio and allows computing Fibonacci numbers efficiently.
+ * <p>
+ * This specific implementation provides a closed-form solution with an expected {@code O(1)} time complexity.
+ * <p>
+ * For alternative approaches to compute or verify Fibonacci numbers, see:
+ * <ul>
+ * <li>{@link com.thealgorithms.maths.FibonacciLoop} - Standard Iterative (Loop) approach</li>
+ * <li>{@link com.thealgorithms.recursion.FibonacciSeries} - Naive Recursive approach</li>
+ * <li>{@link com.thealgorithms.dynamicprogramming.Fibonacci} - Dynamic Programming approaches (Memoization, Bottom-Up, Optimized)</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciJavaStreams} - Functional approach using Java Streams</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberCheck} - Utility to check if a given number is a Fibonacci number</li>
+ * <li>{@link com.thealgorithms.matrix.matrixexponentiation.Fibonacci} - O(log n) Matrix Exponentiation approach</li>
+ * </ul>
  *
  * @see <a href="https://en.wikipedia.org/wiki/Fibonacci_sequence#Binet's_formula">Binet's formula on Wikipedia</a>
  */

--- a/src/main/java/com/thealgorithms/recursion/FibonacciSeries.java
+++ b/src/main/java/com/thealgorithms/recursion/FibonacciSeries.java
@@ -7,8 +7,18 @@ package com.thealgorithms.recursion;
  * Example:
  * 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55 ...
  * </p>
+ * <p>
+ * This specific implementation demonstrates a <b>Naive Recursive approach</b> with {@code O(2^n)} time complexity.
+ * For more performant variations or different programming paradigms, see:
+ * <ul>
+ * <li>{@link com.thealgorithms.maths.FibonacciLoop} - Standard Iterative (Loop) approach</li>
+ * <li>{@link com.thealgorithms.dynamicprogramming.Fibonacci} - Dynamic Programming variants (Memoization / Bottom-Up)</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciJavaStreams} - Functional approach using Java Streams</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberGoldenRation} - Closed-form expression using Binet's formula</li>
+ * <li>{@link com.thealgorithms.maths.FibonacciNumberCheck} - Utility to check if a given number is a Fibonacci number</li>
+ * <li>{@link com.thealgorithms.matrix.matrixexponentiation.Fibonacci} - O(log n) Matrix Exponentiation approach</li>
+ * </ul>
  */
-
 public final class FibonacciSeries {
     private FibonacciSeries() {
         throw new UnsupportedOperationException("Utility class");


### PR DESCRIPTION

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations. (N/A - Documentation update only)
- [ ] All new algorithms include a corresponding test class that validates their functionality. (N/A - Documentation update only)
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`

### Description
The n-th Fibonacci sequence is implemented across several files using entirely different paradigms (Iterative, Streams, Binet's Formula, Recursion, and DP). Currently, a learner looking at one file has no way of knowing the other approaches exist.

### Proposed change
Added standard Javadoc `{@link}` cross-references to the header of the following files:
* `maths/FibonacciLoop.java`
* `maths/FibonacciJavaStreams.java`
* `maths/FibonacciNumberCheck.java`
* `maths/FibonacciNumberGoldenRation.java`
* `dynamicprogramming/Fibonacci.java`
* `recursion/FibonacciSeries.java`

This drastically improves discoverability for learners trying to compare algorithmic approaches, without disrupting the existing package hierarchy.
Fixes #7455