### PR TITLE
fix: Caesar cipher produces non-alphabetic output for negative shifts

### DIFF
--- a/src/main/java/com/thealgorithms/ciphers/Caesar.java
+++ b/src/main/java/com/thealgorithms/ciphers/Caesar.java
@@ -9,8 +9,8 @@ package com.thealgorithms.ciphers;
  * @author khalil2535
  */
 public class Caesar {
-    private static char normalizeShift(final int shift) {
-        return (char) (shift % 26);
+    private static int normalizeShift(final int shift) {
+        return ((shift % 26) + 26) % 26;
     }
 
     /**
@@ -22,21 +22,18 @@ public class Caesar {
     public String encode(String message, int shift) {
         StringBuilder encoded = new StringBuilder();
 
-        final char shiftChar = normalizeShift(shift);
+        final int shiftChar = normalizeShift(shift);
 
         final int length = message.length();
         for (int i = 0; i < length; i++) {
-            //            int current = message.charAt(i); //using char to shift characters because
-            //            ascii
-            // is in-order latin alphabet
-            char current = message.charAt(i); // Java law : char + int = char
+            final char current = message.charAt(i);
 
             if (isCapitalLatinLetter(current)) {
-                current += shiftChar;
-                encoded.append((char) (current > 'Z' ? current - 26 : current)); // 26 = number of latin letters
+                final int shifted = current + shiftChar;
+                encoded.append((char) (shifted > 'Z' ? shifted - 26 : shifted)); // 26 = number of latin letters
             } else if (isSmallLatinLetter(current)) {
-                current += shiftChar;
-                encoded.append((char) (current > 'z' ? current - 26 : current)); // 26 = number of latin letters
+                final int shifted = current + shiftChar;
+                encoded.append((char) (shifted > 'z' ? shifted - 26 : shifted)); // 26 = number of latin letters
             } else {
                 encoded.append(current);
             }
@@ -53,17 +50,17 @@ public class Caesar {
     public String decode(String encryptedMessage, int shift) {
         StringBuilder decoded = new StringBuilder();
 
-        final char shiftChar = normalizeShift(shift);
+        final int shiftChar = normalizeShift(shift);
 
         final int length = encryptedMessage.length();
         for (int i = 0; i < length; i++) {
-            char current = encryptedMessage.charAt(i);
+            final char current = encryptedMessage.charAt(i);
             if (isCapitalLatinLetter(current)) {
-                current -= shiftChar;
-                decoded.append((char) (current < 'A' ? current + 26 : current)); // 26 = number of latin letters
+                final int shifted = current - shiftChar;
+                decoded.append((char) (shifted < 'A' ? shifted + 26 : shifted)); // 26 = number of latin letters
             } else if (isSmallLatinLetter(current)) {
-                current -= shiftChar;
-                decoded.append((char) (current < 'a' ? current + 26 : current)); // 26 = number of latin letters
+                final int shifted = current - shiftChar;
+                decoded.append((char) (shifted < 'a' ? shifted + 26 : shifted)); // 26 = number of latin letters
             } else {
                 decoded.append(current);
             }

--- a/src/test/java/com/thealgorithms/ciphers/CaesarTest.java
+++ b/src/test/java/com/thealgorithms/ciphers/CaesarTest.java
@@ -33,6 +33,29 @@ class CaesarTest {
     }
 
     @Test
+    void caesarEncryptWithNegativeShiftTest() {
+        // a shift of -1 must wrap 'A' backwards to 'Z', like a shift of +25 would
+        assertEquals("Z", caesar.encode("A", -1));
+        assertEquals("z", caesar.encode("a", -1));
+        assertEquals("EBIIL", caesar.encode("HELLO", -3));
+    }
+
+    @Test
+    void caesarDecryptWithNegativeShiftTest() {
+        assertEquals("A", caesar.decode("Z", -1));
+        assertEquals("HELLO", caesar.decode("EBIIL", -3));
+    }
+
+    @Test
+    void caesarNegativeShiftRoundTripTest() {
+        // encode followed by decode with the same shift must return the original text
+        for (int shift : new int[] {-1, -5, -25, -26, -27, -52}) {
+            String message = "The quick brown Fox";
+            assertEquals(message, caesar.decode(caesar.encode(message, shift), shift));
+        }
+    }
+
+    @Test
     void caesarBruteForce() {
         // given
         String encryptedText = "Jshwduy ymnx yjcy";


### PR DESCRIPTION
Fixes #7506

### Problem

`Caesar.encode`/`Caesar.decode` produced corrupted, non-alphabetic output for any negative shift that is not an exact multiple of 26:

```java
new Caesar().encode("A", -1); // returned "@" (ASCII 64) instead of "Z"
```

Root cause: `normalizeShift` did `(char) (shift % 26)`. Java's `%` preserves the dividend's sign, so `-1 % 26 == -1`, and casting a negative `int` to the unsigned 16-bit `char` type wraps it to `65535`. The following char arithmetic then overflowed and truncated into an arbitrary wrong character, which the `> 'Z'` / `< 'A'` wraparound checks could not catch. This also broke the `decode(encode(x, s), s) == x` round-trip for negative shifts.

### Fix

- `normalizeShift` now returns an `int` normalized into `0..25` via `((shift % 26) + 26) % 26`, so a negative shift is mapped to its equivalent positive rotation (e.g. `-1` → `25`).
- The shift arithmetic in `encode`/`decode` is performed in `int` and cast back to `char` only when appending, which also removes the `lossy-conversions` compound-assignment pattern.

### Tests

Added three regression tests to `CaesarTest`:

- `caesarEncryptWithNegativeShiftTest` — `encode("A", -1)` must wrap to `"Z"` (upper and lower case).
- `caesarDecryptWithNegativeShiftTest` — decoding with a negative shift.
- `caesarNegativeShiftRoundTripTest` — encode→decode round-trip for shifts `-1, -5, -25, -26, -27, -52`.

Verified locally: `mvn test -Dtest=CaesarTest` → 6/6 pass, `mvn checkstyle:check` clean, `clang-format --dry-run --Werror` clean. All existing tests still pass unchanged.
