### PR TITLE
docs: correct stale WiggleSort Javadoc — [1, 2, 2] is already detected, add regression tests

### DIFF
--- a/src/main/java/com/thealgorithms/sorts/WiggleSort.java
+++ b/src/main/java/com/thealgorithms/sorts/WiggleSort.java
@@ -11,9 +11,9 @@ import java.util.Arrays;
  * https://cs.stackexchange.com/questions/125372/how-to-wiggle-sort-an-array-in-linear-time-complexity
  * Also have a look at:
  * https://cs.stackexchange.com/questions/125372/how-to-wiggle-sort-an-array-in-linear-time-complexity?noredirect=1&lq=1
- * Not all arrays are wiggle-sortable. This algorithm will find some obviously not wiggle-sortable
- * arrays and throw an error, but there are some exceptions that won't be caught, for example [1, 2,
- * 2].
+ * Not all arrays are wiggle-sortable. This algorithm detects non-wiggle-sortable inputs — for
+ * example [1, 2, 2], or arrays where more than half the values are equal — and throws an
+ * IllegalArgumentException instead of returning a wrongly ordered result.
  */
 public class WiggleSort implements SortAlgorithm {
 

--- a/src/test/java/com/thealgorithms/sorts/WiggleSortTest.java
+++ b/src/test/java/com/thealgorithms/sorts/WiggleSortTest.java
@@ -1,6 +1,7 @@
 package com.thealgorithms.sorts;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
@@ -69,5 +70,23 @@ public class WiggleSortTest {
         String[] result = {"a", "d", "b", "c"};
         wiggleSort.sort(values);
         assertArrayEquals(values, result);
+    }
+
+    @Test
+    void wiggleTestNonWiggleSortableOddArrayThrows() {
+        // [1, 2, 2] is not wiggle-sortable: the median 2 appears ceil(3 / 2) = 2 times
+        // but is not the smallest value, so sorting must fail instead of returning
+        // a wrongly ordered array
+        WiggleSort wiggleSort = new WiggleSort();
+        Integer[] values = {1, 2, 2};
+        assertThrows(IllegalArgumentException.class, () -> wiggleSort.sort(values));
+    }
+
+    @Test
+    void wiggleTestTooManyDuplicatesThrows() {
+        // more than half of the values are the same, which can never be wiggle-sorted
+        WiggleSort wiggleSort = new WiggleSort();
+        Integer[] values = {2, 2, 2, 1};
+        assertThrows(IllegalArgumentException.class, () -> wiggleSort.sort(values));
     }
 }


### PR DESCRIPTION
Fixes #7507

### Problem

The class-level Javadoc of `WiggleSort` claims:

> "there are some exceptions that won't be caught, for example [1, 2, 2]"

This is outdated. The odd-array median guard inside `wiggleSort()` (the `sortThis.length % 2 == 1 && numMedians == ceil(sortThis.length / 2.0)` check, added with a reference to [this cs.stackexchange question](https://cs.stackexchange.com/questions/150886/)) already detects exactly that case and throws `IllegalArgumentException` — verified by running `new WiggleSort().sort(new Integer[]{1, 2, 2})` locally, plus a brute-force sweep over thousands of small arrays (lengths 2–7 with duplicates) that found no case where a non-wiggle-sorted result is silently returned.

The stale comment is misleading: it tells readers the algorithm is known-broken for an input it actually handles, and it discouraged anyone from adding a regression test for that input ("won't be caught anyway").

### Changes

- Rewrote the class Javadoc to describe the current behavior: non-wiggle-sortable inputs such as `[1, 2, 2]` are detected and rejected with `IllegalArgumentException`.
- Added two regression tests locking in that behavior:
  - `wiggleTestNonWiggleSortableOddArrayThrows` — `[1, 2, 2]` must throw (median appears ceil(n/2) times but is not the smallest value).
  - `wiggleTestTooManyDuplicatesThrows` — `[2, 2, 2, 1]` must throw (more than half the values are equal).

No behavior change to the algorithm itself — documentation and tests only.

### Verification

`mvn test -Dtest=WiggleSortTest` → 9/9 pass (7 existing + 2 new), `mvn checkstyle:check` clean, `clang-format --dry-run --Werror` clean.
