### PR TITLE
Enhance Javadoc for AccountMerge

### DIFF
--- a/src/main/java/com/thealgorithms/graph/AccountMerge.java
+++ b/src/main/java/com/thealgorithms/graph/AccountMerge.java
@@ -10,13 +10,25 @@ import java.util.Map;
 /**
  * Merges account records using Disjoint Set Union (Union-Find) on shared emails.
  *
- * <p>Input format: each account is a list where the first element is the user name and the
- * remaining elements are emails.
+ * <p>Each account is expected to be a list where the first element is the user name and the
+ * remaining elements are email addresses. Accounts that share at least one email are merged into a
+ * single record.
  */
 public final class AccountMerge {
     private AccountMerge() {
+        // Utility class; do not instantiate.
     }
 
+    /**
+     * Merges accounts that share one or more email addresses.
+     *
+     * <p>The returned list is sorted by account owner name, then by the first email address when
+     * multiple merged groups have the same owner name. Within each merged account, emails are
+     * returned in lexicographic order.
+     *
+     * @param accounts a list of accounts where each entry contains a user name followed by emails
+     * @return merged accounts, or an empty list when {@code accounts} is null or empty
+     */
     public static List<List<String>> mergeAccounts(List<List<String>> accounts) {
         if (accounts == null || accounts.isEmpty()) {
             return List.of();
@@ -73,6 +85,9 @@ public final class AccountMerge {
         return merged;
     }
 
+    /**
+     * Lightweight union-find structure with path compression and union by rank.
+     */
     private static final class UnionFind {
         private final int[] parent;
         private final int[] rank;


### PR DESCRIPTION
## Description

This PR improves the Javadocs in `AccountMerge.java` to make the class easier to understand and use.

### Changes
- Added documentation describing the expected input format.
- Explained how accounts are merged when they share one or more email addresses.
- Clarified the ordering of the merged results returned by `mergeAccounts(...)`.
- Added detailed method-level Javadocs for `mergeAccounts(...)`.
- Added documentation for the internal `UnionFind` helper class.

### Notes
- No functional code was changed.
- This PR only improves documentation and readability.


- [x] I have read CONTRIBUTING.md.
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [ ] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [ ] All new algorithms include a corresponding test class that validates their functionality.
- [ ] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`