### PR TITLE
fix: reject negative input in SumOfSquares

### DIFF
--- a/src/main/java/com/thealgorithms/maths/SumOfSquares.java
+++ b/src/main/java/com/thealgorithms/maths/SumOfSquares.java
@@ -18,8 +18,13 @@ public final class SumOfSquares {
      *
      * @param n the target number
      * @return minimum number of squares needed
+     * @throws IllegalArgumentException if {@code n} is negative
      */
     public static int minSquares(int n) {
+        if (n < 0) {
+            throw new IllegalArgumentException("Input must be non-negative");
+        }
+
         if (isPerfectSquare(n)) {
             return 1;
         }

--- a/src/test/java/com/thealgorithms/maths/SumOfSquaresTest.java
+++ b/src/test/java/com/thealgorithms/maths/SumOfSquaresTest.java
@@ -1,6 +1,7 @@
 package com.thealgorithms.maths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +64,11 @@ class SumOfSquaresTest {
     @Test
     void testEdgeCases() {
         // Test edge case
-        assertEquals(1, SumOfSquares.minSquares(0)); // 0^2
+    
+    @Test
+    void testNegativeInput() {
+        assertThrows(IllegalArgumentException.class, () -> SumOfSquares.minSquares(-1));
+    }
+    assertEquals(1, SumOfSquares.minSquares(0)); // 0^2
     }
 }

--- a/src/test/java/com/thealgorithms/maths/SumOfSquaresTest.java
+++ b/src/test/java/com/thealgorithms/maths/SumOfSquaresTest.java
@@ -64,11 +64,11 @@ class SumOfSquaresTest {
     @Test
     void testEdgeCases() {
         // Test edge case
-    
+        assertEquals(1, SumOfSquares.minSquares(0)); // 0^2
+    }
+
     @Test
     void testNegativeInput() {
         assertThrows(IllegalArgumentException.class, () -> SumOfSquares.minSquares(-1));
-    }
-    assertEquals(1, SumOfSquares.minSquares(0)); // 0^2
     }
 }


### PR DESCRIPTION
### Description

Rejects negative inputs in SumOfSquares instead of returning the mathematically incorrect result 3.

The public method now throws IllegalArgumentException with a clear message, and its Javadoc documents the behavior.

### Testing

- Added a regression test for negative input
- Compiled the implementation directly with javac
- Verified the existing one-, two-, three-, and four-square cases
- Verified that negative input throws IllegalArgumentException

Closes #7538

### Checklist

- [x] Filenames use PascalCase
- [x] Java naming conventions are followed
- [x] The existing algorithm documentation link is preserved
- [x] The behavior is covered by a corresponding test
- [x] The change follows the existing formatting style

AI assistance was used to prepare this focused fix. I reviewed and validated the implementation.