### PR TITLE
Fix AbsoluteMin comparison by absolute magnitude

### DIFF
--- a/src/main/java/com/thealgorithms/maths/AbsoluteMin.java
+++ b/src/main/java/com/thealgorithms/maths/AbsoluteMin.java
@@ -19,8 +19,7 @@ public final class AbsoluteMin {
         for (int number : numbers) {
             long absoluteNumber = Math.abs((long) number);
             long absoluteMinValue = Math.abs((long) minValue);
-            if (absoluteNumber < absoluteMinValue
-                || (absoluteNumber == absoluteMinValue && number < minValue)) {
+            if (absoluteNumber < absoluteMinValue || (absoluteNumber == absoluteMinValue && number < minValue)) {
                 // For equal absolute values, consistently choose the numerically smaller value.
                 minValue = number;
             }

--- a/src/main/java/com/thealgorithms/maths/AbsoluteMin.java
+++ b/src/main/java/com/thealgorithms/maths/AbsoluteMin.java
@@ -1,7 +1,5 @@
 package com.thealgorithms.maths;
 
-import java.util.Arrays;
-
 public final class AbsoluteMin {
     private AbsoluteMin() {
     }
@@ -17,10 +15,16 @@ public final class AbsoluteMin {
             throw new IllegalArgumentException("Numbers array cannot be empty");
         }
 
-        var absMinWrapper = new Object() { int value = numbers[0]; };
-
-        Arrays.stream(numbers).skip(1).filter(number -> Math.abs(number) <= Math.abs(absMinWrapper.value)).forEach(number -> absMinWrapper.value = Math.min(absMinWrapper.value, number));
-
-        return absMinWrapper.value;
+        int minValue = numbers[0];
+        for (int number : numbers) {
+            long absoluteNumber = Math.abs((long) number);
+            long absoluteMinValue = Math.abs((long) minValue);
+            if (absoluteNumber < absoluteMinValue
+                || (absoluteNumber == absoluteMinValue && number < minValue)) {
+                // For equal absolute values, consistently choose the numerically smaller value.
+                minValue = number;
+            }
+        }
+        return minValue;
     }
 }

--- a/src/test/java/com/thealgorithms/maths/AbsoluteMinTest.java
+++ b/src/test/java/com/thealgorithms/maths/AbsoluteMinTest.java
@@ -9,8 +9,11 @@ public class AbsoluteMinTest {
 
     @Test
     void testGetMinValue() {
+        assertEquals(2, AbsoluteMin.getMinValue(-5, 2));
         assertEquals(0, AbsoluteMin.getMinValue(4, 0, 16));
         assertEquals(-2, AbsoluteMin.getMinValue(3, -10, -2));
+        assertEquals(-2, AbsoluteMin.getMinValue(-5, -2));
+        assertEquals(2, AbsoluteMin.getMinValue(5, 2));
     }
 
     @Test
@@ -21,6 +24,7 @@ public class AbsoluteMinTest {
 
     @Test
     void testGetMinValueWithSameAbsoluteValues() {
+        assertEquals(-3, AbsoluteMin.getMinValue(-3, 3));
         assertEquals(-5, AbsoluteMin.getMinValue(-5, 5));
         assertEquals(-5, AbsoluteMin.getMinValue(5, -5));
     }


### PR DESCRIPTION
## Summary

- compare candidates by absolute magnitude and return the original signed value
- preserve the existing deterministic tie behavior by choosing the numerically smaller value
- add coverage for mixed signs, both-negative, both-positive, equal magnitudes, and zero

## Root cause

`AbsoluteMin.getMinValue` filtered candidates using their absolute values, but then updated the result with `Math.min` on the raw signed values. A larger-magnitude negative number could therefore replace the correct candidate.

## Validation

- `javac` compilation and direct behavior checks passed
- `git diff --check` passed
- `mvn -Dtest=AbsoluteMinTest test` reached test compilation, but the upstream checkout has unrelated missing-class compilation failures across existing tests before Surefire can select the focused test

Fixes #7537
