### PR TITLE
fix: reject null array in BitonicSort with IllegalArgumentException

### DIFF
--- a/src/main/java/com/thealgorithms/sorts/BitonicSort.java
+++ b/src/main/java/com/thealgorithms/sorts/BitonicSort.java
@@ -21,6 +21,9 @@ public class BitonicSort implements SortAlgorithm {
      */
     @Override
     public <T extends Comparable<T>> T[] sort(T[] array) {
+        if (array == null) {
+            throw new IllegalArgumentException("Array must not be null");
+        }
         if (array.length == 0) {
             return array;
         }

--- a/src/test/java/com/thealgorithms/sorts/BitonicSortTest.java
+++ b/src/test/java/com/thealgorithms/sorts/BitonicSortTest.java
@@ -1,8 +1,17 @@
 package com.thealgorithms.sorts;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
 public class BitonicSortTest extends SortingAlgorithmTest {
     @Override
     SortAlgorithm getSortAlgorithm() {
         return new BitonicSort();
+    }
+
+    @Test
+    void testNullArrayThrowsIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> getSortAlgorithm().sort((Integer[]) null));
     }
 }


### PR DESCRIPTION
### Description
`BitonicSort.sort` previously dereferenced a null array when reading `array.length`, producing an incidental `NullPointerException`.

Validate null input first, throw a clear `IllegalArgumentException`, and add a regression test.

Fixes #7549