### PR TITLE
Fix ExponentialSearch missing boundary elements and not returning -1

### DIFF
--- a/src/main/java/com/thealgorithms/searches/ExponentialSearch.java
+++ b/src/main/java/com/thealgorithms/searches/ExponentialSearch.java
@@ -46,6 +46,9 @@ class ExponentialSearch implements SearchAlgorithm {
             range = range * 2;
         }
 
-        return Arrays.binarySearch(array, range / 2, Math.min(range, array.length), key);
+        // The candidate block is the inclusive index range [range / 2, range], so the
+        // exclusive upper bound handed to binarySearch has to be range + 1.
+        final int index = Arrays.binarySearch(array, range / 2, Math.min(range + 1, array.length), key);
+        return index >= 0 ? index : -1;
     }
 }

--- a/src/test/java/com/thealgorithms/searches/ExponentialSearchTest.java
+++ b/src/test/java/com/thealgorithms/searches/ExponentialSearchTest.java
@@ -81,4 +81,46 @@ class ExponentialSearchTest {
         int expectedIndex = 9999;
         assertEquals(expectedIndex, exponentialSearch.find(array, key), "The index of the last element should be 9999.");
     }
+
+    /**
+     * An element sitting exactly on the doubling boundary used to be reported as missing, because
+     * the binary search was handed {@code range} as its exclusive upper bound instead of
+     * {@code range + 1}.
+     */
+    @Test
+    void testExponentialSearchElementOnRangeBoundary() {
+        ExponentialSearch exponentialSearch = new ExponentialSearch();
+        Integer[] array = {-25, -9, 8, 21};
+        assertEquals(2, exponentialSearch.find(array, 8), "The index of the found element should be 2.");
+    }
+
+    /**
+     * Every element must be found regardless of the array length.
+     */
+    @Test
+    void testExponentialSearchFindsEveryElement() {
+        ExponentialSearch exponentialSearch = new ExponentialSearch();
+        for (int length = 1; length <= 50; length++) {
+            Integer[] array = new Integer[length];
+            for (int i = 0; i < length; i++) {
+                array[i] = i * 2;
+            }
+            for (int i = 0; i < length; i++) {
+                assertEquals(i, exponentialSearch.find(array, i * 2), "Element at index " + i + " should be found for length " + length + ".");
+            }
+        }
+    }
+
+    /**
+     * A missing key has to yield -1 rather than the negative insertion point that
+     * {@link java.util.Arrays#binarySearch} returns.
+     */
+    @Test
+    void testExponentialSearchNotFoundReturnsMinusOne() {
+        ExponentialSearch exponentialSearch = new ExponentialSearch();
+        Integer[] array = {1, 3, 5, 7, 9, 11};
+        assertEquals(-1, exponentialSearch.find(array, 4), "A key inside the range but absent should give -1.");
+        assertEquals(-1, exponentialSearch.find(array, 0), "A key below the minimum should give -1.");
+        assertEquals(-1, exponentialSearch.find(array, 12), "A key above the maximum should give -1.");
+    }
 }


### PR DESCRIPTION
`ExponentialSearch.find` has two defects.

**1. It reports present elements as missing.**

After the doubling loop the candidate block is the *inclusive* index range `[range / 2, range]`, but `Arrays.binarySearch` takes an *exclusive* `toIndex`:

```java
return Arrays.binarySearch(array, range / 2, Math.min(range, array.length), key);
```

Index `range` — the element that stopped the doubling loop — is therefore never examined, so any key that lands exactly on a doubling boundary is not found:

```java
new ExponentialSearch().find(new Integer[] {-25, -9, 8, 21}, 8); // -3, expected 2
```

Randomised testing over sorted `Integer` arrays of length 1–12 hits this on roughly 4% of present keys.

**2. A missing key does not return -1.**

The Javadoc promises "The index of the key if found, otherwise -1", but the raw result of `Arrays.binarySearch` is returned, which is `-(insertion point) - 1` when absent:

```java
new ExponentialSearch().find(new Integer[] {1, 3, 5, 7, 9, 11}, 4); // -3, expected -1
```

This also breaks the `SearchAlgorithm` contract that every other implementation in the package honours. The existing "not found" test only used an empty array, which returns `-1` early and so hid the problem.

### Fix

```java
final int index = Arrays.binarySearch(array, range / 2, Math.min(range + 1, array.length), key);
return index >= 0 ? index : -1;
```

### Tests

- `testExponentialSearchElementOnRangeBoundary` — the minimal reproducer for the off-by-one.
- `testExponentialSearchFindsEveryElement` — every index of every array of length 1–50.
- `testExponentialSearchNotFoundReturnsMinusOne` — absent keys below, inside and above the array range.

All three fail on `master` and pass with the fix.

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new algorithms include a corresponding test class that validates their functionality.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`
