### PR TITLE
fix: integer overflow in MobiusFunction

### DIFF
--- a/src/main/java/com/thealgorithms/maths/Prime/MobiusFunction.java
+++ b/src/main/java/com/thealgorithms/maths/Prime/MobiusFunction.java
@@ -31,25 +31,26 @@ public final class MobiusFunction {
             throw new IllegalArgumentException("Number must be greater than zero.");
         }
 
-        if (number == 1) {
-            // return 1 if number passed is less or is 1
-            return 1;
-        }
-
         int primeFactorCount = 0;
+        int remaining = number;
 
-        for (int i = 1; i <= number; i++) {
-            // find prime factors of number
-            if (number % i == 0 && PrimeCheck.isPrime(i)) {
-                // check if number is divisible by square of prime factor
-                if (number % (i * i) == 0) {
-                    // if number is divisible by square of prime factor
+        /* Divide out every prime factor in turn. Trial division only has to run up to the square
+        root of the remaining value, and the multiplication is widened to long so that the bound
+        does not overflow for numbers close to Integer.MAX_VALUE. */
+        for (int factor = 2; (long) factor * factor <= remaining; factor++) {
+            if (remaining % factor == 0) {
+                remaining /= factor;
+                if (remaining % factor == 0) {
+                    // number is divisible by the square of this prime factor
                     return 0;
                 }
-                /*increment primeFactorCount by 1
-                                if number is not divisible by square of found prime factor*/
                 primeFactorCount++;
             }
+        }
+
+        /* Whatever is left is either 1 or a single prime factor larger than the square root. */
+        if (remaining > 1) {
+            primeFactorCount++;
         }
 
         return (primeFactorCount % 2 == 0) ? 1 : -1;

--- a/src/test/java/com/thealgorithms/maths/prime/MobiusFunctionTest.java
+++ b/src/test/java/com/thealgorithms/maths/prime/MobiusFunctionTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.thealgorithms.maths.Prime.MobiusFunction;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class MobiusFunctionTest {
 
@@ -151,5 +153,16 @@ class MobiusFunctionTest {
             // then
             assertEquals(expectedValue, actualValue);
         }
+    }
+
+    /**
+     * Large inputs whose smallest square divisor test used to overflow, most notably
+     * {@code Integer.MAX_VALUE}, whose square wraps around to 1 and made every number look like it
+     * had a squared prime factor.
+     */
+    @ParameterizedTest
+    @CsvSource({"2147483647, -1", "2147483646, 0", "2147483645, -1", "2147483644, 0", "2147483629, -1", "2147395600, 0", "1073741824, 0", "1073741789, -1", "999999937, -1", "999999999, 0", "2146689000, 0"})
+    void testMobiusForLargeNumbers(int number, int expected) {
+        assertEquals(expected, MobiusFunction.mobius(number));
     }
 }


### PR DESCRIPTION
### Problem

`MobiusFunction.mobius` decides whether a prime factor is repeated with `number % (i * i) == 0`, where `i` is an `int`. The product overflows for `i > 46340`, and the wrapped value can still divide `number`, which makes the method report a squared prime factor that does not exist.

The worst case is `Integer.MAX_VALUE`, whose square wraps to exactly `1`. Since every number is divisible by 1, the method returns `0` for it:

```java
MobiusFunction.mobius(2147483647);  // returns 0, expected -1 (2147483647 is prime)
```

Separately, the loop `for (int i = 1; i <= number; i++)` calls `PrimeCheck.isPrime(i)` on every value up to `number`, so the method is `O(n * sqrt(n))`. `mobius(2147483647)` performs on the order of 2^31 iterations, each with a primality check.

### Fix

Replaced the scan over all candidates with ordinary trial division that divides each prime factor out of a running remainder:

- the loop bound is `(long) factor * factor <= remaining`, widened to `long` so it cannot overflow near `Integer.MAX_VALUE`;
- a factor found twice in a row means a squared prime factor, so the method returns `0`;
- whatever remains after the loop is either `1` or a single prime larger than the square root, and is counted once.

This removes the overflow and drops the complexity from `O(n * sqrt(n))` to `O(sqrt(n))` — `mobius(Integer.MAX_VALUE)` now returns immediately. The explicit `number == 1` early return is no longer needed: the loop does not execute and the factor count of `0` yields `1`, which is the same result.

Behaviour is otherwise unchanged, including the `IllegalArgumentException` for non-positive input.

### Tests

`MobiusFunctionTest` previously only checked 1..100, all of which are well below the overflow threshold. Added a parameterized case over large inputs, including `Integer.MAX_VALUE` and its neighbours, perfect powers of two, `46340^2` and large primes. `mobius(2147483647)` fails on the old code.

- [x] I have read [CONTRIBUTING.md](https://github.com/TheAlgorithms/Java/blob/master/CONTRIBUTING.md).
- [x] This pull request is all my own work -- I have not plagiarized it.
- [x] All filenames are in PascalCase.
- [x] All functions and variable names follow Java naming conventions.
- [x] All new algorithms have a URL in their comments that points to Wikipedia or other similar explanations.
- [x] All new algorithms include a corresponding test class that validates their functionality.
- [x] All new code is formatted with `clang-format -i --style=file path/to/your/file.java`
